### PR TITLE
feat: add staff dashboard endpoint and UI components

### DIFF
--- a/backend/src/modules/reports/dto/report-response.dto.ts
+++ b/backend/src/modules/reports/dto/report-response.dto.ts
@@ -56,3 +56,13 @@ export class TopInteractivePostDto {
   @ApiProperty({ example: 57, description: 'Total = Votes + Comments' })
   totalInteractions: number;
 }
+export class RadarStatsDto {
+  @ApiProperty({ example: 'January' })
+  month: string;
+
+  @ApiProperty({ example: 120, description: 'Resolved + Rejected' })
+  resolved: number;
+
+  @ApiProperty({ example: 50, description: 'Pending + In Progress' })
+  unresolved: number;
+}

--- a/backend/src/modules/reports/reports.controller.ts
+++ b/backend/src/modules/reports/reports.controller.ts
@@ -16,17 +16,20 @@ import {
   TopDepartmentStatsDto,
   FeedbackTrendDto,
   TopInteractivePostDto,
+  RadarStatsDto,
 } from './dto/report-response.dto';
+import { ActiveUser } from '../auth/decorators/active-user.decorator';
+import type { ActiveUserData } from '../auth/interfaces/active-user-data.interface';
 
 @ApiTags('Admin Reports')
 @ApiBearerAuth()
 @UseGuards(RolesGuard)
 @Roles(UserRole.ADMIN) // Chỉ Admin mới xem được
-@Controller('admin/reports')
+@Controller('reports')
 export class ReportsController {
   constructor(private readonly reportsService: ReportsService) {}
 
-  @Get('overview')
+  @Get('admin/overview')
   @ApiOperation({
     summary: 'Get general feedback statistics (Counts by status)',
   })
@@ -35,7 +38,7 @@ export class ReportsController {
     return this.reportsService.getGeneralOverview(query);
   }
 
-  @Get('departments')
+  @Get('admin/departments')
   @ApiOperation({
     summary: 'Get performance stats by department (Volume & Resolution Time)',
   })
@@ -44,25 +47,92 @@ export class ReportsController {
     return this.reportsService.getTopDepartments(query);
   }
 
-  @Get('trends')
+  @Get('admin/trends')
   @ApiOperation({ summary: 'Get feedback volume trends over time' })
   @ApiResponse({ status: 200, type: [FeedbackTrendDto] })
   async getTrends(@Query() query: ReportFilterDto) {
     return this.reportsService.getFeedbackTrends(query);
   }
 
-  @Get('categories')
+  @Get('admin/categories')
   @ApiOperation({ summary: 'Get top 5 categories with most feedbacks' })
   async getTopCategories(@Query() query: ReportFilterDto) {
     return this.reportsService.getTopCategories(query);
   }
 
-  @Get('top-interactive-posts')
+  @Get('admin/top-interactive-posts')
   @ApiOperation({
     summary: 'Get top 5 forum posts with most interactions (votes + comments)',
   })
   @ApiResponse({ status: 200, type: [TopInteractivePostDto] })
   async getTopInteractivePosts(@Query() query: ReportFilterDto) {
     return this.reportsService.getTopInteractivePosts(query);
+  }
+
+  // 1. Tổng quan số liệu (Staff)
+  @Get('staff/overview')
+  @Roles(UserRole.DEPARTMENT_STAFF)
+  @ApiOperation({ summary: 'Get overview stats for current department' })
+  @ApiResponse({ status: 200, type: StatsOverviewDto })
+  async getStaffOverview(
+    @Query() query: ReportFilterDto,
+    @ActiveUser() actor: ActiveUserData,
+  ) {
+    return this.reportsService.getStaffOverview(query, actor.departmentId!);
+  }
+
+  // 2. Top Category (Staff)
+  @Get('staff/categories')
+  @Roles(UserRole.DEPARTMENT_STAFF)
+  @ApiOperation({ summary: 'Get top categories for current department' })
+  async getStaffTopCategories(
+    @Query() query: ReportFilterDto,
+    @ActiveUser() actor: ActiveUserData,
+  ) {
+    return this.reportsService.getStaffTopCategories(
+      query,
+      actor.departmentId!,
+    );
+  }
+
+  // 3. Trends (Staff)
+  @Get('staff/trends')
+  @Roles(UserRole.DEPARTMENT_STAFF)
+  @ApiOperation({ summary: 'Get feedback trends for current department' })
+  @ApiResponse({ status: 200, type: [FeedbackTrendDto] })
+  async getStaffTrends(
+    @Query() query: ReportFilterDto,
+    @ActiveUser() actor: ActiveUserData,
+  ) {
+    return this.reportsService.getStaffFeedbackTrends(
+      query,
+      actor.departmentId!,
+    );
+  }
+
+  // 4. Performance (Staff)
+  @Get('staff/performance')
+  @Roles(UserRole.DEPARTMENT_STAFF)
+  @ApiOperation({ summary: 'Get performance metrics for current department' })
+  @ApiResponse({ status: 200, type: TopDepartmentStatsDto })
+  async getStaffPerformance(
+    @Query() query: ReportFilterDto,
+    @ActiveUser() actor: ActiveUserData,
+  ) {
+    return this.reportsService.getStaffPerformance(query, actor.departmentId!);
+  }
+
+  // 5. Radar Chart (Staff)
+  @Get('staff/radar-chart')
+  @Roles(UserRole.DEPARTMENT_STAFF)
+  @ApiOperation({
+    summary: 'Get data for Radar Chart (Resolved vs Unresolved)',
+  })
+  @ApiResponse({ status: 200, type: [RadarStatsDto] })
+  async getStaffRadarChart(
+    @Query() query: ReportFilterDto,
+    @ActiveUser() actor: ActiveUserData,
+  ) {
+    return this.reportsService.getStaffRadarChart(query, actor.departmentId!);
   }
 }

--- a/backend/src/modules/reports/reports.service.ts
+++ b/backend/src/modules/reports/reports.service.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // src/modules/reports/reports.service.ts
@@ -10,6 +12,7 @@ import {
   TopDepartmentStatsDto,
   FeedbackTrendDto,
   TopInteractivePostDto,
+  RadarStatsDto,
 } from './dto/report-response.dto';
 
 @Injectable()
@@ -183,5 +186,194 @@ export class ReportsService {
     `;
 
     return result;
+  }
+
+  // 1. Staff Overview
+  async getStaffOverview(
+    dto: ReportFilterDto,
+    departmentId: string,
+  ): Promise<StatsOverviewDto> {
+    const dateFilter = this.getDateFilter(dto);
+
+    // Thêm điều kiện departmentId
+    const where: Prisma.FeedbacksWhereInput = {
+      ...dateFilter,
+      departmentId: departmentId,
+    };
+
+    const groups = await this.prisma.feedbacks.groupBy({
+      by: ['currentStatus'],
+      where: where,
+      _count: { _all: true },
+    });
+
+    const result = {
+      totalFeedbacks: 0,
+      pendingCount: 0,
+      inProgressCount: 0,
+      resolvedCount: 0,
+      rejectedCount: 0,
+    };
+
+    groups.forEach((g) => {
+      result.totalFeedbacks += g._count._all;
+      if (g.currentStatus === 'PENDING') result.pendingCount = g._count._all;
+      if (g.currentStatus === 'IN_PROGRESS')
+        result.inProgressCount = g._count._all;
+      if (g.currentStatus === 'RESOLVED') result.resolvedCount = g._count._all;
+      if (g.currentStatus === 'REJECTED') result.rejectedCount = g._count._all;
+    });
+
+    return result;
+  }
+
+  // 2. Staff Top Categories
+  async getStaffTopCategories(dto: ReportFilterDto, departmentId: string) {
+    const dateFilter = this.getDateFilter(dto);
+    const where: Prisma.FeedbacksWhereInput = {
+      ...dateFilter,
+      departmentId: departmentId,
+    };
+
+    const result = await this.prisma.feedbacks.groupBy({
+      by: ['categoryId'],
+      where,
+      _count: { id: true },
+      orderBy: { _count: { id: 'desc' } },
+      take: 5,
+    });
+
+    const categoryIds = result.map((r) => r.categoryId);
+    const categories = await this.prisma.categories.findMany({
+      where: { id: { in: categoryIds } },
+      select: { id: true, name: true },
+    });
+
+    return result.map((r) => ({
+      categoryName:
+        categories.find((c) => c.id === r.categoryId)?.name || 'Unknown',
+      count: r._count.id,
+      categoryId: r.categoryId,
+    }));
+  }
+
+  // 3. Staff Trends
+  async getStaffFeedbackTrends(
+    dto: ReportFilterDto,
+    departmentId: string,
+  ): Promise<FeedbackTrendDto[]> {
+    const fromDate = dto.from
+      ? new Date(dto.from)
+      : new Date(new Date().setDate(new Date().getDate() - 30));
+    const toDate = dto.to
+      ? new Date(new Date(dto.to).setDate(new Date(dto.to).getDate() + 1))
+      : new Date();
+
+    // FIX: Thêm ::uuid sau biến ${departmentId}
+    const trends: any[] = await this.prisma.$queryRaw`
+      SELECT 
+        TO_CHAR(f."createdAt", 'YYYY-MM-DD') as date,
+        COUNT(f.id)::int as count
+      FROM "Feedbacks" f
+      WHERE f."departmentId" = ${departmentId}::uuid 
+        AND f."createdAt" >= ${fromDate} 
+        AND f."createdAt" < ${toDate}
+      GROUP BY TO_CHAR(f."createdAt", 'YYYY-MM-DD')
+      ORDER BY date ASC;
+    `;
+
+    return trends;
+  }
+
+  // 4. Staff Performance
+  async getStaffPerformance(
+    dto: ReportFilterDto,
+    departmentId: string,
+  ): Promise<TopDepartmentStatsDto> {
+    const fromDate = dto.from ? new Date(dto.from) : new Date('2000-01-01');
+    const toDate = dto.to
+      ? new Date(new Date(dto.to).setDate(new Date(dto.to).getDate() + 1))
+      : new Date();
+
+    // FIX: Thêm ::uuid sau biến ${departmentId} ở điều kiện WHERE d.id
+    const rawData: any[] = await this.prisma.$queryRaw`
+      SELECT 
+        d.id as "departmentId",
+        d.name as "departmentName",
+        COUNT(f.id)::int as "feedbackCount",
+        COUNT(CASE WHEN f."currentStatus" IN ('PENDING', 'IN_PROGRESS') THEN 1 END)::int as "unresolvedCount",
+        COUNT(CASE WHEN f."currentStatus" IN ('RESOLVED', 'REJECTED') THEN 1 END)::int as "resolvedCount",
+        COALESCE(
+          AVG(
+            EXTRACT(EPOCH FROM (h."createdAt" - f."createdAt")) / 3600
+          ) FILTER (WHERE h.status = 'RESOLVED'), 
+          0
+        )::float as "avgResolutionTimeHours"
+      FROM "Departments" d
+      LEFT JOIN "Feedbacks" f ON f."departmentId" = d.id AND f."createdAt" >= ${fromDate} AND f."createdAt" < ${toDate}
+      LEFT JOIN "FeedbackStatusHistory" h ON f.id = h."feedbackId" AND h.status = 'RESOLVED'
+      WHERE d.id = ${departmentId}::uuid
+      GROUP BY d.id, d.name;
+    `;
+
+    return rawData[0] || null;
+  }
+  // 5. Staff Radar Chart
+  async getStaffRadarChart(
+    dto: ReportFilterDto,
+    departmentId: string,
+  ): Promise<RadarStatsDto[]> {
+    // 1. Xác định Năm cần thống kê
+    // Lấy năm từ ngày 'to' (hoặc ngày hiện tại nếu không có filter)
+    // Ví dụ: User chọn range T2/2025 -> T4/2025 => Lấy dữ liệu cả năm 2025
+    const targetDate = dto.to ? new Date(dto.to) : new Date();
+    const year = targetDate.getFullYear();
+
+    // Tạo mốc thời gian đầu năm và đầu năm sau
+    const startOfYear = new Date(year, 0, 1); // 01/01/YYYY
+    const endOfYear = new Date(year + 1, 0, 1); // 01/01/(YYYY+1)
+
+    // 2. Query DB (Vẫn giữ ::uuid để tránh lỗi)
+    const rawData: any[] = await this.prisma.$queryRaw`
+      SELECT
+        EXTRACT(MONTH FROM f."createdAt")::int as "monthNum",
+        COUNT(CASE WHEN f."currentStatus" IN ('RESOLVED', 'REJECTED') THEN 1 END)::int as "resolved",
+        COUNT(CASE WHEN f."currentStatus" IN ('PENDING', 'IN_PROGRESS') THEN 1 END)::int as "unresolved"
+      FROM "Feedbacks" f
+      WHERE f."departmentId" = ${departmentId}::uuid
+        AND f."createdAt" >= ${startOfYear} 
+        AND f."createdAt" < ${endOfYear}
+      GROUP BY "monthNum"
+      ORDER BY "monthNum" ASC;
+    `;
+
+    // 3. Chuẩn hóa dữ liệu cho đủ 12 tháng
+    const fullYearData: RadarStatsDto[] = [];
+    const monthNames = [
+      'Tháng 1',
+      'Tháng 2',
+      'Tháng 3',
+      'Tháng 4',
+      'Tháng 5',
+      'Tháng 6',
+      'Tháng 7',
+      'Tháng 8',
+      'Tháng 9',
+      'Tháng 10',
+      'Tháng 11',
+      'Tháng 12',
+    ];
+
+    for (let i = 0; i < 12; i++) {
+      const foundMonth = rawData.find((r) => r.monthNum === i + 1);
+
+      fullYearData.push({
+        month: monthNames[i],
+        resolved: foundMonth ? foundMonth.resolved : 0,
+        unresolved: foundMonth ? foundMonth.unresolved : 0,
+      });
+    }
+
+    return fullYearData;
   }
 }

--- a/frontend/src/app/(layout)/admin/dashboard/page.tsx
+++ b/frontend/src/app/(layout)/admin/dashboard/page.tsx
@@ -95,7 +95,11 @@ export default function AdminDashboardPage() {
           <FeedbackTrendChart data={trends} isLoading={loadingTrends} />
         </div>
         <div className="col-span-1 h-full lg:col-span-4">
-          <TopCategoriesChart data={categories} isLoading={loadingCategories} />
+          <TopCategoriesChart
+            data={categories}
+            isLoading={loadingCategories}
+            type="admin"
+          />
         </div>
       </div>
     </Wrapper>

--- a/frontend/src/app/(layout)/staff/dashboard/page.tsx
+++ b/frontend/src/app/(layout)/staff/dashboard/page.tsx
@@ -1,0 +1,175 @@
+"use client";
+import { FeedbackTrendChart } from "@/components/dashboard/admin/FeedbackTrendChart";
+import { MonthRangePicker } from "@/components/dashboard/admin/MonthRangePicker";
+import { SingleDeptPerformanceChart } from "@/components/dashboard/admin/SingleDeptPerformanceChart";
+import { StaffRadarChart } from "@/components/dashboard/admin/StaffRadarChart";
+import { StatsOverviewCards } from "@/components/dashboard/admin/StatsOverviewCards";
+import { TopCategoriesChart } from "@/components/dashboard/admin/TopCategoriesChart";
+import Wrapper from "@/components/shared/Wrapper";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  useGetStaffFeedbackTrends,
+  useGetStaffPerformance,
+  useGetStaffRadarChart,
+  useGetStaffStatsOverview,
+  useGetStaffTopCategories,
+} from "@/hooks/queries/useReportQueries";
+import { ReportFilter } from "@/types/report";
+import { endOfMonth, format, startOfMonth } from "date-fns";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useMemo } from "react";
+
+export default function StaffDashboardPage() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  // 1. Filter Logic (Giống Admin)
+  const filter = useMemo((): ReportFilter => {
+    const fromParam = searchParams.get("from");
+    const toParam = searchParams.get("to");
+    const now = new Date();
+
+    return {
+      from: fromParam || format(startOfMonth(now), "yyyy-MM-dd"),
+      to: toParam || format(endOfMonth(now), "yyyy-MM-dd"),
+    };
+  }, [searchParams]);
+
+  const handleDateUpdate = useCallback(
+    (newRange: ReportFilter) => {
+      const params = new URLSearchParams(searchParams);
+      if (newRange.from) params.set("from", newRange.from);
+      if (newRange.to) params.set("to", newRange.to);
+
+      router.push(`${pathname}?${params.toString()}`, { scroll: false });
+    },
+    [pathname, router, searchParams],
+  );
+
+  // 2. Fetching Data (Dùng Hooks của Staff)
+  const { data: overview, isLoading: loadingOverview } =
+    useGetStaffStatsOverview(filter);
+
+  const { data: trends, isLoading: loadingTrends } =
+    useGetStaffFeedbackTrends(filter);
+
+  const { data: categories, isLoading: loadingCategories } =
+    useGetStaffTopCategories(filter);
+
+  const { data: performance, isLoading: loadingPerformance } =
+    useGetStaffPerformance(filter);
+  const { data: radarData, isLoading: loadingRadar } =
+    useGetStaffRadarChart(filter);
+  return (
+    <Wrapper>
+      {/* Header */}
+      <div className="flex w-full flex-col items-start justify-between gap-4 md:flex-row md:items-center">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight text-slate-900 md:text-3xl">
+            Tổng quan phòng ban
+          </h1>
+          <p className="text-muted-foreground text-sm md:text-base">
+            Thống kê hoạt động xử lý góp ý của đơn vị.
+          </p>
+        </div>
+        <MonthRangePicker
+          onUpdate={handleDateUpdate}
+          defaultFrom={filter.from}
+          defaultTo={filter.to}
+        />
+      </div>
+
+      <section className="w-full">
+        <StatsOverviewCards data={overview} isLoading={loadingOverview} />
+      </section>
+
+      <div className="grid w-full grid-cols-1 gap-4 lg:grid-cols-8">
+        {/* Trend Chart */}
+        <div className="col-span-1 lg:col-span-4">
+          <FeedbackTrendChart data={trends} isLoading={loadingTrends} />
+        </div>
+        <div className="col-span-1 h-full w-full lg:col-span-4">
+          <TopCategoriesChart
+            data={categories}
+            isLoading={loadingCategories}
+            type="staff"
+          />
+        </div>
+      </div>
+
+      <div className="grid w-full grid-cols-1 gap-4 pb-4 lg:grid-cols-8">
+        <div className="col-span-1 lg:col-span-4">
+          {/* Tự tạo Card wrapper cho Staff Dashboard */}
+          <Card className="flex h-full flex-col items-center justify-start">
+            <CardHeader className="w-full pb-2">
+              <CardTitle>Hiệu suất xử lý</CardTitle>
+              <CardDescription>Thời gian trung bình</CardDescription>
+            </CardHeader>
+            <CardContent className="flex w-full justify-center pb-6">
+              {loadingPerformance ? (
+                <div className="h-[200px] w-full animate-pulse rounded-xl bg-gray-100" />
+              ) : performance ? (
+                <SingleDeptPerformanceChart
+                  dept={performance}
+                  className="scale-110"
+                />
+              ) : (
+                <div className="text-muted-foreground py-10">
+                  Chưa có dữ liệu
+                </div>
+              )}
+            </CardContent>
+            <CardFooter className="flex-col gap-3 border-t pt-1 text-xs">
+              <div className="flex w-full flex-col items-center gap-2">
+                <div className="text-muted-foreground flex items-center gap-4">
+                  <div className="flex items-center gap-1">
+                    <div className="h-2 w-2 rounded-full bg-[hsl(221.2,83.2%,53.3%)]"></div>
+                    <span>Đã xử lý</span>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <div className="h-2 w-2 rounded-full bg-[hsl(0,84.2%,60.2%)]"></div>
+                    <span>Chưa xử lý</span>
+                  </div>
+                </div>
+
+                <div className="text-muted-foreground flex flex-wrap items-center gap-3 text-[10px]">
+                  <div className="flex items-center gap-1">
+                    <div className="h-2 w-2 rounded-full bg-slate-400"></div>
+                    <span>N/A</span>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <div className="h-2 w-2 rounded-full bg-emerald-500"></div>
+                    <span>&lt;24h (Tốt)</span>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <div className="h-2 w-2 rounded-full bg-amber-500"></div>
+                    <span>24-72h (TB)</span>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <div className="h-2 w-2 rounded-full bg-rose-500"></div>
+                    <span>&gt;72h (Kém)</span>
+                  </div>
+                </div>
+              </div>
+            </CardFooter>
+          </Card>
+        </div>
+        <div className="col-span-1 lg:col-span-4">
+          <StaffRadarChart
+            data={radarData}
+            isLoading={loadingRadar}
+            filter={filter}
+          />
+        </div>
+      </div>
+    </Wrapper>
+  );
+}

--- a/frontend/src/components/dashboard/admin/DepartmentPerformanceRadial.tsx
+++ b/frontend/src/components/dashboard/admin/DepartmentPerformanceRadial.tsx
@@ -1,7 +1,6 @@
 "use client";
 import { useMemo, useState } from "react";
 import { Search, ChevronLeft, ChevronRight } from "lucide-react";
-import { Label, PolarRadiusAxis, RadialBar, RadialBarChart } from "recharts";
 import {
   Card,
   CardContent,
@@ -10,29 +9,11 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import {
-  ChartConfig,
-  ChartContainer,
-  ChartTooltip,
-  ChartTooltipContent,
-} from "@/components/ui/chart";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { TopDepartmentStatsDto } from "@/types/report";
-import { cn } from "@/lib/utils";
 import Link from "next/link";
-
-// Cấu hình màu sắc Chart
-const chartConfig = {
-  resolved: {
-    label: "Đã xử lý",
-    color: "hsl(221.2 83.2% 53.3%)", // Blue tone
-  },
-  unresolved: {
-    label: "Chưa xử lý",
-    color: "hsl(0 84.2% 60.2%)", // Red tone
-  },
-} satisfies ChartConfig;
+import { SingleDeptPerformanceChart } from "./SingleDeptPerformanceChart"; // Import component vừa tách
 
 const ITEMS_PER_PAGE = 6;
 
@@ -40,92 +21,6 @@ interface Props {
   data?: TopDepartmentStatsDto[];
   isLoading: boolean;
 }
-
-const getPerformanceColor = (hours: number) => {
-  if (hours === 0) return "fill-slate-400/80";
-  if (hours <= 24) return "fill-emerald-400/80";
-  if (hours <= 72) return "fill-amber-400/80";
-  return "fill-rose-400/80";
-};
-
-const SingleDeptChart = ({ dept }: { dept: TopDepartmentStatsDto }) => {
-  const chartData = [
-    {
-      month: "data",
-      resolved: dept.resolvedCount,
-      unresolved: dept.unresolvedCount,
-    },
-  ];
-
-  const performanceColor = getPerformanceColor(dept.avgResolutionTimeHours);
-
-  return (
-    <div className="flex flex-col items-center rounded-lg p-2 transition-colors hover:bg-slate-50">
-      <div
-        className="mb-2 line-clamp-1 h-5 w-full px-2 text-center text-sm font-medium"
-        title={dept.departmentName}
-      >
-        {dept.departmentName}
-      </div>
-      <ChartContainer
-        config={chartConfig}
-        className="mx-auto aspect-square w-full max-w-40"
-      >
-        <RadialBarChart
-          data={chartData}
-          endAngle={180}
-          innerRadius={55}
-          outerRadius={90}
-        >
-          <ChartTooltip
-            cursor={false}
-            content={<ChartTooltipContent hideLabel />}
-          />
-          <PolarRadiusAxis tick={false} tickLine={false} axisLine={false}>
-            <Label
-              content={({ viewBox }) => {
-                if (viewBox && "cx" in viewBox && "cy" in viewBox) {
-                  return (
-                    <text x={viewBox.cx} y={viewBox.cy} textAnchor="middle">
-                      <tspan
-                        x={viewBox.cx}
-                        y={(viewBox.cy || 0) - 16}
-                        className={cn("text-xl font-bold", performanceColor)}
-                      >
-                        {dept.avgResolutionTimeHours.toFixed(1)}h
-                      </tspan>
-                      <tspan
-                        x={viewBox.cx}
-                        y={(viewBox.cy || 0) + 4}
-                        className="fill-muted-foreground text-[10px]"
-                      >
-                        Trung bình
-                      </tspan>
-                    </text>
-                  );
-                }
-              }}
-            />
-          </PolarRadiusAxis>
-          <RadialBar
-            dataKey="unresolved"
-            fill="var(--color-unresolved)"
-            stackId="a"
-            cornerRadius={5}
-            className="stroke-transparent stroke-2"
-          />
-          <RadialBar
-            dataKey="resolved"
-            fill="var(--color-resolved)"
-            stackId="a"
-            cornerRadius={5}
-            className="stroke-transparent stroke-2"
-          />
-        </RadialBarChart>
-      </ChartContainer>
-    </div>
-  );
-};
 
 export function DepartmentPerformanceRadial({ data, isLoading }: Props) {
   const [searchTerm, setSearchTerm] = useState("");
@@ -207,7 +102,8 @@ export function DepartmentPerformanceRadial({ data, isLoading }: Props) {
                 className="cursor-pointer"
                 href={`/admin/feedbacks-management?departmentId=${dept.departmentId}`}
               >
-                <SingleDeptChart dept={dept} />
+                {/* Sử dụng component con */}
+                <SingleDeptPerformanceChart dept={dept} />
               </Link>
             ))}
           </div>

--- a/frontend/src/components/dashboard/admin/SingleDeptPerformanceChart.tsx
+++ b/frontend/src/components/dashboard/admin/SingleDeptPerformanceChart.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { TopDepartmentStatsDto } from "@/types/report";
+import { cn } from "@/lib/utils";
+import { Label, PolarRadiusAxis, RadialBar, RadialBarChart } from "recharts";
+import {
+  ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+
+// Cấu hình màu sắc Chart
+const chartConfig = {
+  resolved: {
+    label: "Đã xử lý",
+    color: "hsl(221.2 83.2% 53.3%)", // Blue tone
+  },
+  unresolved: {
+    label: "Chưa xử lý",
+    color: "hsl(0 84.2% 60.2%)", // Red tone
+  },
+} satisfies ChartConfig;
+
+const getPerformanceColor = (hours: number) => {
+  if (hours === 0) return "fill-slate-400/80";
+  if (hours <= 24) return "fill-emerald-400/80";
+  if (hours <= 72) return "fill-amber-400/80";
+  return "fill-rose-400/80";
+};
+
+interface Props {
+  dept: TopDepartmentStatsDto;
+  className?: string; // Cho phép override style container nếu cần
+}
+
+export const SingleDeptPerformanceChart = ({ dept, className }: Props) => {
+  const chartData = [
+    {
+      month: "data",
+      resolved: dept.resolvedCount,
+      unresolved: dept.unresolvedCount,
+    },
+  ];
+
+  const performanceColor = getPerformanceColor(dept.avgResolutionTimeHours);
+
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center rounded-lg p-2 transition-colors hover:bg-slate-50",
+        className,
+      )}
+    >
+      <div
+        className="mb-2 line-clamp-1 h-5 w-full px-2 text-center text-sm font-medium"
+        title={dept.departmentName}
+      >
+        {dept.departmentName}
+      </div>
+      <ChartContainer
+        config={chartConfig}
+        className="mx-auto aspect-square w-full max-w-40"
+      >
+        <RadialBarChart
+          data={chartData}
+          endAngle={180}
+          innerRadius={55}
+          outerRadius={90}
+        >
+          <ChartTooltip
+            cursor={false}
+            content={<ChartTooltipContent hideLabel />}
+          />
+          <PolarRadiusAxis tick={false} tickLine={false} axisLine={false}>
+            <Label
+              content={({ viewBox }) => {
+                if (viewBox && "cx" in viewBox && "cy" in viewBox) {
+                  return (
+                    <text x={viewBox.cx} y={viewBox.cy} textAnchor="middle">
+                      <tspan
+                        x={viewBox.cx}
+                        y={(viewBox.cy || 0) - 16}
+                        className={cn("text-xl font-bold", performanceColor)}
+                      >
+                        {dept.avgResolutionTimeHours.toFixed(1)}h
+                      </tspan>
+                      <tspan
+                        x={viewBox.cx}
+                        y={(viewBox.cy || 0) + 4}
+                        className="fill-muted-foreground text-[10px]"
+                      >
+                        Trung bình
+                      </tspan>
+                    </text>
+                  );
+                }
+              }}
+            />
+          </PolarRadiusAxis>
+          <RadialBar
+            dataKey="unresolved"
+            fill="var(--color-unresolved)"
+            stackId="a"
+            cornerRadius={5}
+            className="stroke-transparent stroke-2"
+          />
+          <RadialBar
+            dataKey="resolved"
+            fill="var(--color-resolved)"
+            stackId="a"
+            cornerRadius={5}
+            className="stroke-transparent stroke-2"
+          />
+        </RadialBarChart>
+      </ChartContainer>
+    </div>
+  );
+};

--- a/frontend/src/components/dashboard/admin/StaffRadarChart.tsx
+++ b/frontend/src/components/dashboard/admin/StaffRadarChart.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { PolarAngleAxis, PolarGrid, Radar, RadarChart } from "recharts";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import { RadarStatsDto, ReportFilter } from "@/types/report";
+import { useMemo } from "react";
+
+// Config màu sắc: Blue (Resolved) & Red (Unresolved)
+const chartConfig = {
+  resolved: {
+    label: "Đã xử lý",
+    color: "hsl(221.2 83.2% 53.3%)", // Blue tone
+  },
+  unresolved: {
+    label: "Chưa xử lý",
+    color: "hsl(0 84.2% 60.2%)", // Red tone
+  },
+} satisfies ChartConfig;
+
+interface Props {
+  data?: RadarStatsDto[];
+  isLoading: boolean;
+  filter: ReportFilter; // Nhận filter để hiển thị năm
+}
+
+export function StaffRadarChart({ data, isLoading, filter }: Props) {
+  // Lấy năm từ filter để hiển thị lên UI
+  const displayYear = useMemo(() => {
+    if (filter.to) return new Date(filter.to).getFullYear();
+    return new Date().getFullYear();
+  }, [filter.to]);
+
+  if (isLoading) {
+    return (
+      <div className="h-[350px] w-full animate-pulse rounded-xl bg-gray-100" />
+    );
+  }
+
+  return (
+    <Card className="flex h-full flex-col">
+      <CardHeader className="items-center pb-4">
+        <CardTitle>Tổng quan năm {displayYear}</CardTitle>
+        <CardDescription>
+          So sánh trạng thái xử lý theo từng tháng
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex-1 pb-0">
+        <ChartContainer
+          config={chartConfig}
+          className="mx-auto aspect-square max-h-[300px] w-full"
+        >
+          <RadarChart data={data || []}>
+            <ChartTooltip
+              cursor={false}
+              content={<ChartTooltipContent indicator="line" />}
+            />
+            <PolarAngleAxis
+              dataKey="month"
+              tick={{ fontSize: 12 }}
+              // Có thể format lại tên tháng cho ngắn gọn nếu cần (Jan, Feb...)
+              tickFormatter={(val) => val.replace("Tháng ", "T")}
+            />
+            <PolarGrid />
+
+            <Radar
+              dataKey="resolved"
+              fill="var(--color-resolved)"
+              fillOpacity={0.5}
+              stroke="var(--color-resolved)"
+              strokeWidth={2}
+            />
+
+            <Radar
+              dataKey="unresolved"
+              fill="var(--color-unresolved)"
+              fillOpacity={0.5}
+              stroke="var(--color-unresolved)"
+              strokeWidth={2}
+            />
+          </RadarChart>
+        </ChartContainer>
+      </CardContent>
+      <CardFooter className="flex-col gap-2 border-t pt-4 text-sm">
+        <div className="text-muted-foreground flex w-full items-center justify-center gap-6 text-xs">
+          <div className="flex items-center gap-2">
+            <div className="h-3 w-3 rounded-sm border border-[hsl(221.2,83.2%,53.3%)] bg-[hsl(221.2,83.2%,53.3%)] opacity-50"></div>
+            <span>Đã xử lý </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="h-3 w-3 rounded-sm border border-[hsl(0,84.2%,60.2%)] bg-[hsl(0,84.2%,60.2%)] opacity-50"></div>
+            <span>Chưa xử lý </span>
+          </div>
+        </div>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/frontend/src/components/dashboard/admin/TopCategoriesChart.tsx
+++ b/frontend/src/components/dashboard/admin/TopCategoriesChart.tsx
@@ -41,9 +41,10 @@ const chartConfig = {
 interface Props {
   data?: TopCategoryDto[];
   isLoading: boolean;
+  type?: "admin" | "staff";
 }
 
-export const TopCategoriesChart = ({ data, isLoading }: Props) => {
+export const TopCategoriesChart = ({ data, isLoading, type }: Props) => {
   const router = useRouter(); // 2. Init router
 
   if (isLoading)
@@ -99,7 +100,9 @@ export const TopCategoriesChart = ({ data, isLoading }: Props) => {
               onClick={(entry: any) => {
                 const id = entry.categoryId || entry.id;
                 if (id) {
-                  router.push(`/admin/feedbacks-management?categoryId=${id}`);
+                  router.push(
+                    `/${type === "staff" ? "staff/list-feedbacks" : "admin/feedbacks-management"}?categoryId=${id}`,
+                  );
                 }
               }}
             >

--- a/frontend/src/constants/navigation.ts
+++ b/frontend/src/constants/navigation.ts
@@ -35,7 +35,7 @@ export const staffNavigation: NavigationItem[] = [
     icon: Megaphone,
   },
   { href: "/notifications", label: "Thông báo", icon: Bell },
-  { href: "#6", label: "Thống kê", icon: ChartColumn },
+  { href: "/staff/dashboard", label: "Thống kê", icon: ChartColumn },
   { href: "/change-password", label: "Đổi mật khẩu", icon: KeyRound },
 ];
 export const adminNavigation: NavigationItem[] = [

--- a/frontend/src/hooks/queries/useReportQueries.ts
+++ b/frontend/src/hooks/queries/useReportQueries.ts
@@ -6,6 +6,11 @@ import {
   getFeedbackTrends,
   getTopCategories,
   getTopInteractivePosts,
+  getStaffFeedbackTrends,
+  getStaffPerformance,
+  getStaffTopCategories,
+  getStaffStatsOverview,
+  getStaffRadarChart,
 } from "@/services/report-service";
 import { ReportFilter } from "@/types/report";
 
@@ -15,6 +20,12 @@ export const REPORT_QUERY_KEYS = {
   trends: "report-trends",
   categories: "report-categories",
   interactivePosts: "report-interactive-posts",
+
+  staffOverview: "staff-report-overview",
+  staffCategories: "staff-report-categories",
+  staffTrends: "staff-report-trends",
+  staffPerformance: "staff-report-performance",
+  staffRadar: "staff-report-radar",
 };
 
 export const useGetStatsOverview = (filter: ReportFilter) => {
@@ -54,5 +65,44 @@ export const useGetTopInteractivePosts = (filter: ReportFilter) => {
     queryKey: [REPORT_QUERY_KEYS.interactivePosts, filter],
     queryFn: () => getTopInteractivePosts(filter),
     placeholderData: (previousData) => previousData,
+  });
+};
+
+export const useGetStaffStatsOverview = (filter: ReportFilter) => {
+  return useQuery({
+    queryKey: [REPORT_QUERY_KEYS.staffOverview, filter],
+    queryFn: () => getStaffStatsOverview(filter),
+    placeholderData: (previousData) => previousData,
+  });
+};
+
+export const useGetStaffTopCategories = (filter: ReportFilter) => {
+  return useQuery({
+    queryKey: [REPORT_QUERY_KEYS.staffCategories, filter],
+    queryFn: () => getStaffTopCategories(filter),
+    placeholderData: (previousData) => previousData,
+  });
+};
+
+export const useGetStaffFeedbackTrends = (filter: ReportFilter) => {
+  return useQuery({
+    queryKey: [REPORT_QUERY_KEYS.staffTrends, filter],
+    queryFn: () => getStaffFeedbackTrends(filter),
+    placeholderData: (previousData) => previousData,
+  });
+};
+
+export const useGetStaffPerformance = (filter: ReportFilter) => {
+  return useQuery({
+    queryKey: [REPORT_QUERY_KEYS.staffPerformance, filter],
+    queryFn: () => getStaffPerformance(filter),
+    placeholderData: (previousData) => previousData,
+  });
+};
+export const useGetStaffRadarChart = (filter: ReportFilter) => {
+  return useQuery({
+    queryKey: [REPORT_QUERY_KEYS.staffRadar, filter],
+    queryFn: () => getStaffRadarChart(filter),
+    placeholderData: (previousData) => previousData, // Giữ data cũ khi đổi năm để tránh layout shift
   });
 };

--- a/frontend/src/services/report-service.ts
+++ b/frontend/src/services/report-service.ts
@@ -7,10 +7,11 @@ import {
   FeedbackTrendDto,
   TopCategoryDto,
   TopInteractivePostDto,
+  RadarStatsDto,
 } from "@/types/report";
 
-const reportBaseUrl = "/admin/reports";
-
+const reportBaseUrl = "/reports/admin";
+const staffReportUrl = "/reports/staff";
 export const getStatsOverview = async (
   filter: ReportFilter,
 ): Promise<StatsOverviewDto> => {
@@ -63,6 +64,57 @@ export const getTopInteractivePosts = async (
 ): Promise<TopInteractivePostDto[]> => {
   const response = await axiosInstance.get<TopInteractivePostDto[]>(
     `${reportBaseUrl}/top-interactive-posts`,
+    {
+      params: filter,
+    },
+  );
+  return response;
+};
+export const getStaffStatsOverview = async (
+  filter: ReportFilter,
+): Promise<StatsOverviewDto> => {
+  const response = await axiosInstance.get<StatsOverviewDto>(
+    `${staffReportUrl}/overview`,
+    { params: filter },
+  );
+  return response;
+};
+
+export const getStaffTopCategories = async (
+  filter: ReportFilter,
+): Promise<TopCategoryDto[]> => {
+  const response = await axiosInstance.get<TopCategoryDto[]>(
+    `${staffReportUrl}/categories`,
+    { params: filter },
+  );
+  return response;
+};
+
+export const getStaffFeedbackTrends = async (
+  filter: ReportFilter,
+): Promise<FeedbackTrendDto[]> => {
+  const response = await axiosInstance.get<FeedbackTrendDto[]>(
+    `${staffReportUrl}/trends`,
+    { params: filter },
+  );
+  return response;
+};
+
+export const getStaffPerformance = async (
+  filter: ReportFilter,
+): Promise<TopDepartmentStatsDto> => {
+  // Lưu ý: Backend trả về 1 Object (TopDepartmentStatsDto), không phải Array
+  const response = await axiosInstance.get<TopDepartmentStatsDto>(
+    `${staffReportUrl}/performance`,
+    { params: filter },
+  );
+  return response;
+};
+export const getStaffRadarChart = async (
+  filter: ReportFilter,
+): Promise<RadarStatsDto[]> => {
+  const response = await axiosInstance.get<RadarStatsDto[]>(
+    `${staffReportUrl}/radar-chart`,
     {
       params: filter,
     },

--- a/frontend/src/types/report.ts
+++ b/frontend/src/types/report.ts
@@ -43,3 +43,9 @@ export type TopInteractivePostDto = {
   commentCount: number;
   totalInteractions: number;
 };
+
+export type RadarStatsDto = {
+  month: string;
+  resolved: number;
+  unresolved: number;
+};


### PR DESCRIPTION
- Implemented new DTO for radar statistics (RadarStatsDto).
- Updated ReportsController to include staff-specific endpoints for overview, categories, trends, performance, and radar chart.
- Enhanced ReportsService with methods to handle staff data retrieval.
- Created StaffDashboardPage with hooks for fetching staff-specific statistics.
- Developed SingleDeptPerformanceChart and StaffRadarChart components for visualizing performance and radar data.
- Updated TopCategoriesChart to support both admin and staff views.
- Modified navigation to include a link to the staff dashboard.
- Added new query hooks for staff report data retrieval.

What's new:
<img width="1919" height="970" alt="image" src="https://github.com/user-attachments/assets/38595855-d296-4201-9060-769291541104" />
<img width="1919" height="1021" alt="image" src="https://github.com/user-attachments/assets/4842c7ae-e3db-4c22-9621-b21f1d7da2d5" />
