### PR TITLE
BUG-05: Fix access control when fetching announcement details

### DIFF
--- a/backend/src/modules/announcements/announcements.controller.ts
+++ b/backend/src/modules/announcements/announcements.controller.ts
@@ -22,6 +22,7 @@ import {
   AnnouncementParamDto,
   CreateAnnouncementDto,
   QueryAnnouncementsDto,
+  QueryStaffAnnouncementsDto,
   UpdateAnnouncementDto,
 } from './dto';
 import { Roles } from '../auth/decorators/roles.decorator';
@@ -36,6 +37,42 @@ import { RolesGuard } from '../auth/guards/roles.guard';
 export class AnnouncementsController {
   constructor(private readonly announcementsService: AnnouncementsService) {}
 
+  //STAFF
+  @Get('staff')
+  @ApiOkResponse({
+    description: 'List announcements',
+    type: AnnouncementListResponseDto,
+  })
+  @ApiOperation({ summary: 'Get all announcements (Authenticated users only)' })
+  @UseGuards(RolesGuard)
+  @Roles(UserRole.DEPARTMENT_STAFF)
+  getStaffAnnouncements(
+    @Query() query: QueryStaffAnnouncementsDto,
+    @ActiveUser() user: ActiveUserData,
+  ): Promise<AnnouncementListResponseDto> {
+    return this.announcementsService.getStaffAnnouncements(query, user);
+  }
+
+  @Get('staff/:id')
+  @ApiOkResponse({
+    description: 'Get announcement detail by ID',
+    type: AnnouncementDetailDto,
+  })
+  @ApiOperation({
+    summary: 'Get announcement detail by ID (Authenticated users only)',
+  })
+  @UseGuards(RolesGuard)
+  @Roles(UserRole.DEPARTMENT_STAFF)
+  getStaffAnnouncementDetail(
+    @Param() params: AnnouncementParamDto,
+    @ActiveUser() user: ActiveUserData,
+  ): Promise<AnnouncementDetailDto> {
+    return this.announcementsService.getStaffAnnouncementDetail(
+      params.id,
+      user,
+    );
+  }
+  //GENERAL
   @Get()
   @ApiOkResponse({
     description: 'List announcements',

--- a/backend/src/modules/announcements/dto/query-announcements.dto.ts
+++ b/backend/src/modules/announcements/dto/query-announcements.dto.ts
@@ -54,3 +54,39 @@ export class QueryAnnouncementsDto {
   @IsISO8601()
   to?: string;
 }
+export class QueryStaffAnnouncementsDto {
+  @ApiPropertyOptional({ description: 'Page number', example: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @ApiPropertyOptional({ description: 'Number of items per page', example: 10 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  pageSize?: number;
+
+  @ApiPropertyOptional({ description: 'Search query', example: 'maintenance' })
+  @IsOptional()
+  @IsString()
+  q?: string;
+
+  @ApiPropertyOptional({
+    description: 'Start date (ISO8601)',
+    example: '2025-09-01',
+  })
+  @IsOptional()
+  @IsISO8601()
+  from?: string;
+
+  @ApiPropertyOptional({
+    description: 'End date (ISO8601)',
+    example: '2025-09-10',
+  })
+  @IsOptional()
+  @IsISO8601()
+  to?: string;
+}


### PR DESCRIPTION
fixes #90

- Add staff-only endpoints for fetching announcements and announcement details
- Separate staff access from public announcement detail
