### PR TITLE
Fix/bug-11/change response format for invalid get requests

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -3,6 +3,7 @@ import { AppModule } from './app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { ValidationPipe } from '@nestjs/common';
 import cookieParser from 'cookie-parser';
+import { ValidationExceptionFilter } from './shared/filter/validation_exception_filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -31,6 +32,7 @@ async function bootstrap() {
       forbidNonWhitelisted: true,
     }),
   );
+  app.useGlobalFilters(new ValidationExceptionFilter());
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api', app, document, {
     swaggerOptions: {

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -3,7 +3,7 @@ import { AppModule } from './app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { ValidationPipe } from '@nestjs/common';
 import cookieParser from 'cookie-parser';
-import { ValidationExceptionFilter } from './shared/filter/validation_exception_filter';
+// import { ValidationExceptionFilter } from './shared/filter/validation_exception_filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -32,7 +32,7 @@ async function bootstrap() {
       forbidNonWhitelisted: true,
     }),
   );
-  app.useGlobalFilters(new ValidationExceptionFilter());
+  // app.useGlobalFilters(new ValidationExceptionFilter());
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api', app, document, {
     swaggerOptions: {

--- a/backend/src/modules/announcements/dto/announcement-param.dto.ts
+++ b/backend/src/modules/announcements/dto/announcement-param.dto.ts
@@ -1,11 +1,11 @@
-import { IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { IsUUID } from 'class-validator';
 
 export class AnnouncementParamDto {
   @ApiProperty({
     description: 'ID of the announcement',
     example: '550e8400-e29b-41d4-a716-44665544004d',
   })
-  @IsString()
+  @IsUUID('loose')
   id: string;
 }

--- a/backend/src/modules/announcements/dto/query-announcements.dto.ts
+++ b/backend/src/modules/announcements/dto/query-announcements.dto.ts
@@ -1,5 +1,12 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsInt, IsISO8601, IsOptional, IsString, Min } from 'class-validator';
+import {
+  IsInt,
+  IsISO8601,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Min,
+} from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class QueryAnnouncementsDto {
@@ -22,7 +29,7 @@ export class QueryAnnouncementsDto {
     example: '550e8400-e29b-41d4-a716-446655440001',
   })
   @IsOptional()
-  @IsString()
+  @IsUUID('loose')
   departmentId?: string;
 
   @ApiPropertyOptional({
@@ -30,7 +37,7 @@ export class QueryAnnouncementsDto {
     example: '550e8400-e29b-41d4-a716-44665544000c',
   })
   @IsOptional()
-  @IsString()
+  @IsUUID('loose')
   userId?: string;
 
   @ApiPropertyOptional({ description: 'Search query', example: 'maintenance' })

--- a/backend/src/modules/categories/dto/category-param.dto.ts
+++ b/backend/src/modules/categories/dto/category-param.dto.ts
@@ -1,11 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString } from 'class-validator';
+import { IsUUID } from 'class-validator';
 
 export class CategoryParamDto {
   @ApiProperty({
     description: 'The UUID of the category.',
     example: '550e8400-e29b-41d4-a716-446655440000',
   })
-  @IsString()
+  @IsUUID('loose')
   categoryId: string;
 }

--- a/backend/src/modules/clarifications/dto/clarification-param.dto.ts
+++ b/backend/src/modules/clarifications/dto/clarification-param.dto.ts
@@ -1,11 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString } from 'class-validator';
+import { IsUUID } from 'class-validator';
 
 export class ClarificationParamDto {
   @ApiProperty({
     description: 'The ID of the clarification conversation.',
     example: '550e8400-e29b-41d4-a716-44665544003e',
   })
-  @IsString()
+  @IsUUID('loose')
   conversationId: string;
 }

--- a/backend/src/modules/clarifications/dto/create-clarification.dto.ts
+++ b/backend/src/modules/clarifications/dto/create-clarification.dto.ts
@@ -1,12 +1,12 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsOptional, IsString, MinLength } from 'class-validator';
+import { IsOptional, IsString, IsUUID, MinLength } from 'class-validator';
 
 export class CreateClarificationDto {
   @ApiProperty({
     description: 'The ID of the feedback this conversation is related to.',
     example: '550e8400-e29b-41d4-a716-446655440013',
   })
-  @IsString()
+  @IsUUID('loose')
   feedbackId: string;
 
   @ApiProperty({

--- a/backend/src/modules/clarifications/dto/query-clarifications.dto.ts
+++ b/backend/src/modules/clarifications/dto/query-clarifications.dto.ts
@@ -2,8 +2,8 @@ import {
   IsBooleanString,
   IsInt,
   IsOptional,
-  IsString,
   Min,
+  IsUUID,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiPropertyOptional } from '@nestjs/swagger';
@@ -14,7 +14,7 @@ export class QueryClarificationsDto {
     example: '550e8400-e29b-41d4-a716-446655440013',
   })
   @IsOptional()
-  @IsString()
+  @IsUUID('loose')
   feedbackId?: string;
 
   @ApiPropertyOptional({

--- a/backend/src/modules/comment/dto/comment-param.dto.ts
+++ b/backend/src/modules/comment/dto/comment-param.dto.ts
@@ -1,10 +1,10 @@
-import { IsString } from 'class-validator';
+import { IsUUID } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 export class CommentParamDto {
   @ApiProperty({
     example: '550e8400-e29b-41d4-a716-446655440034',
     description: 'Unique ID of the comment',
   })
-  @IsString()
+  @IsUUID('loose')
   commentId: string;
 }

--- a/backend/src/modules/comment/dto/create-comment.dto.ts
+++ b/backend/src/modules/comment/dto/create-comment.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsString, MinLength } from 'class-validator';
+import { IsOptional, IsString, IsUUID, MinLength } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateCommentDto {
@@ -16,6 +16,6 @@ export class CreateCommentDto {
     nullable: true,
   })
   @IsOptional()
-  @IsString()
+  @IsUUID('loose')
   parentId?: string | null;
 }

--- a/backend/src/modules/departments/dto/department-param.dto.ts
+++ b/backend/src/modules/departments/dto/department-param.dto.ts
@@ -1,13 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString } from 'class-validator';
+import { IsUUID } from 'class-validator';
 
 export class DepartmentParamDto {
   @ApiProperty({
     description: 'The UUID of the department.',
     example: '550e8400-e29b-41d4-a716-446655440000',
   })
-  // Commented out to allow flexibility in parameter types
-  // @IsUUID()
-  @IsString()
+  @IsUUID('loose')
   departmentId: string;
 }

--- a/backend/src/modules/feedback_management/dto/create-forwarding.dto.ts
+++ b/backend/src/modules/feedback_management/dto/create-forwarding.dto.ts
@@ -1,12 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, IsString } from 'class-validator';
+import { IsOptional, IsString, IsUUID } from 'class-validator';
 
 export class CreateForwardingDto {
   @ApiProperty({
     example: '550e8400-e29b-41d4-a716-446655440001',
     description: 'ID of the department the feedback will be forwarded to',
   })
-  @IsString()
+  @IsUUID('loose')
   toDepartmentId: string;
 
   @ApiProperty({

--- a/backend/src/modules/feedbacks/dto/create-feedback.dto.ts
+++ b/backend/src/modules/feedbacks/dto/create-feedback.dto.ts
@@ -5,6 +5,7 @@ import {
   MinLength,
   ValidateNested,
   IsArray,
+  IsUUID,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
@@ -44,14 +45,14 @@ export class CreateFeedbackDto {
     description:
       'The ID of the feedback category (linked to the Categories table).',
   })
-  @IsString()
+  @IsUUID('loose')
   categoryId: string;
 
   @ApiProperty({
     example: '550e8400-e29b-41d4-a716-446655440003',
     description: 'The ID of the department receiving the feedback.',
   })
-  @IsString()
+  @IsUUID('loose')
   departmentId: string;
 
   @ApiProperty({

--- a/backend/src/modules/feedbacks/dto/feedback-param.dto.ts
+++ b/backend/src/modules/feedbacks/dto/feedback-param.dto.ts
@@ -1,10 +1,10 @@
-import { IsString } from 'class-validator';
+import { IsUUID } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 export class FeedbackParamDto {
   @ApiProperty({
     example: '550e8400-e29b-41d4-a716-446655440018',
     description: 'Unique ID of the feedback to retrieve details for',
   })
-  @IsString()
+  @IsUUID('loose')
   feedbackId: string;
 }

--- a/backend/src/modules/feedbacks/dto/query-my-feedbacks.dto.ts
+++ b/backend/src/modules/feedbacks/dto/query-my-feedbacks.dto.ts
@@ -1,7 +1,14 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { FeedbackStatus } from '@prisma/client';
 import { Type } from 'class-transformer';
-import { IsInt, IsISO8601, IsOptional, IsString, Min } from 'class-validator';
+import {
+  IsInt,
+  IsISO8601,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Min,
+} from 'class-validator';
 
 export class QueryFeedbacksDto {
   @ApiPropertyOptional({ example: 1, description: 'Current page number' })
@@ -35,7 +42,7 @@ export class QueryFeedbacksDto {
     description: 'Filter by category ID',
   })
   @IsOptional()
-  @IsString()
+  @IsUUID('loose')
   categoryId?: string;
 
   @ApiPropertyOptional({
@@ -43,7 +50,7 @@ export class QueryFeedbacksDto {
     description: 'Filter by department ID',
   })
   @IsOptional()
-  @IsString()
+  @IsUUID('loose')
   departmentId?: string;
 
   @ApiPropertyOptional({

--- a/backend/src/modules/forum/dto/get-post-param.dto.ts
+++ b/backend/src/modules/forum/dto/get-post-param.dto.ts
@@ -1,8 +1,8 @@
-import { IsString } from 'class-validator';
+import { IsUUID } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class PostParamDto {
-  @IsString()
+  @IsUUID('loose')
   @ApiProperty({
     example: '550e8400-e29b-41d4-a716-44665544002e',
     description: 'Post ID',

--- a/backend/src/modules/forum/dto/query-posts.dto.ts
+++ b/backend/src/modules/forum/dto/query-posts.dto.ts
@@ -1,5 +1,12 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsInt, IsISO8601, IsOptional, IsString, Min } from 'class-validator';
+import {
+  IsInt,
+  IsISO8601,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Min,
+} from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class QueryPostsDto {
@@ -22,7 +29,7 @@ export class QueryPostsDto {
     description: 'Filter by categoryId',
   })
   @IsOptional()
-  @IsString()
+  @IsUUID('loose')
   categoryId?: string;
 
   @ApiPropertyOptional({
@@ -30,7 +37,7 @@ export class QueryPostsDto {
     description: 'Filter by departmentId',
   })
   @IsOptional()
-  @IsString()
+  @IsUUID('loose')
   departmentId?: string;
 
   @ApiPropertyOptional({

--- a/backend/src/modules/moderation/dto/comment-report-param.dto.ts
+++ b/backend/src/modules/moderation/dto/comment-report-param.dto.ts
@@ -1,10 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString } from 'class-validator';
+import { IsUUID } from 'class-validator';
 export class CommentReportParamDto {
   @ApiProperty({
     example: '550e8400-e29b-41d4-a716-44665544003b',
     description: 'Unique ID of the comment report',
   })
-  @IsString()
+  @IsUUID('loose')
   commentReportId: string;
 }

--- a/backend/src/modules/notifications/dto/create-notification.dto.ts
+++ b/backend/src/modules/notifications/dto/create-notification.dto.ts
@@ -5,6 +5,7 @@ import {
   IsString,
   IsArray,
   IsOptional,
+  IsUUID,
 } from 'class-validator';
 import { NotificationType } from '@prisma/client';
 
@@ -32,7 +33,7 @@ export class CreateNotificationsDto {
   type: NotificationType;
 
   @ApiProperty({ description: 'The ID of the related entity' })
-  @IsString()
+  @IsUUID('loose')
   targetId: string | null;
 
   @ApiProperty({ description: 'The title of the related entity' })

--- a/backend/src/modules/notifications/dto/notification-param.dto.ts
+++ b/backend/src/modules/notifications/dto/notification-param.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString } from 'class-validator';
+import { IsUUID } from 'class-validator';
 
 export class NotificationParamDto {
   @ApiProperty({
@@ -7,6 +7,6 @@ export class NotificationParamDto {
     type: String,
   })
   // @IsUUID()
-  @IsString()
+  @IsUUID('loose')
   id: string;
 }

--- a/backend/src/modules/uploads/dto/file-attachment.dto.ts
+++ b/backend/src/modules/uploads/dto/file-attachment.dto.ts
@@ -1,12 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsInt, IsNotEmpty, IsString, IsUrl } from 'class-validator';
+import { IsInt, IsNotEmpty, IsString, IsUrl, IsUUID } from 'class-validator';
 
 export class FileAttachmentDto {
   @ApiProperty({
     example: '550e8400-e29b-41d4-a716-44665544004a',
     description: 'Unique ID of the file attachment',
   })
-  @IsString()
+  @IsUUID('loose')
   id: string;
 
   @ApiProperty({

--- a/backend/src/modules/users/dto/get-user-param.dto.ts
+++ b/backend/src/modules/users/dto/get-user-param.dto.ts
@@ -1,6 +1,6 @@
-import { IsString } from 'class-validator';
+import { IsUUID } from 'class-validator';
 
 export class GetUserParamDto {
-  @IsString()
+  @IsUUID('loose')
   userId: string;
 }

--- a/backend/src/shared/filter/validation_exception_filter.ts
+++ b/backend/src/shared/filter/validation_exception_filter.ts
@@ -1,0 +1,77 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import {
+  ArgumentsHost,
+  BadRequestException,
+  Catch,
+  ExceptionFilter,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+
+@Catch(BadRequestException)
+export class ValidationExceptionFilter implements ExceptionFilter {
+  catch(exception: BadRequestException, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+
+    const exceptionResponse = exception.getResponse() as any;
+    const messages = exceptionResponse?.message ?? [];
+
+    const hasParams = Object.keys(request.params || {}).length > 0;
+    const hasQuery = Object.keys(request.query || {}).length > 0;
+    const hasBody = Object.keys(request.body || {}).length > 0;
+
+    /**
+     * CASE 1: Param invalid → 404
+     */
+    console.log('hasParams:', hasParams);
+    console.log('hasQuery:', hasQuery);
+    console.log('messages:', messages);
+    if (hasParams) {
+      return response.status(404).json({
+        statusCode: 404,
+        message: 'Resource not found',
+        error: 'Not Found',
+      });
+    }
+
+    /**
+     * CASE 2: Query invalid → 200 []
+     */
+    if (hasQuery) {
+      return response.status(200).json({
+        result: [],
+        total: 0,
+      });
+    }
+
+    /**
+     * CASE 3: Body invalid → giữ 400
+     */
+    return response.status(400).json({
+      statusCode: 400,
+      message: messages,
+    });
+  }
+
+  //   private isParamError(messages: string[]): boolean {
+  //     return messages.some(
+  //       (msg) =>
+  //         msg.toLowerCase().includes('uuid') ||
+  //         msg.toLowerCase().includes('param'),
+  //     );
+  //   }
+
+  //   private isQueryError(messages: string[]): boolean {
+  //     return messages.some(
+  //       (msg) =>
+  //         msg.toLowerCase().includes('page') ||
+  //         msg.toLowerCase().includes('limit') ||
+  //         msg.toLowerCase().includes('query'),
+  //     );
+  //   }
+}

--- a/backend/src/shared/filter/validation_exception_filter.ts
+++ b/backend/src/shared/filter/validation_exception_filter.ts
@@ -1,8 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable @typescript-eslint/no-unsafe-argument */
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import {
   ArgumentsHost,
   BadRequestException,
@@ -10,7 +5,9 @@ import {
   ExceptionFilter,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
-
+type BadRequestResponse = {
+  message?: string | string[];
+};
 @Catch(BadRequestException)
 export class ValidationExceptionFilter implements ExceptionFilter {
   catch(exception: BadRequestException, host: ArgumentsHost) {
@@ -18,12 +15,14 @@ export class ValidationExceptionFilter implements ExceptionFilter {
     const response = ctx.getResponse<Response>();
     const request = ctx.getRequest<Request>();
 
-    const exceptionResponse = exception.getResponse() as any;
+    console.log(exception.getResponse());
+    const exceptionResponse = exception.getResponse() as BadRequestResponse;
+    console.log('exceptionResponse:', exceptionResponse);
     const messages = exceptionResponse?.message ?? [];
 
     const hasParams = Object.keys(request.params || {}).length > 0;
     const hasQuery = Object.keys(request.query || {}).length > 0;
-    const hasBody = Object.keys(request.body || {}).length > 0;
+    // const hasBody = Object.keys(request.body || {}).length > 0;
 
     /**
      * CASE 1: Param invalid → 404

--- a/backend/src/shared/filter/validation_exception_filter.ts
+++ b/backend/src/shared/filter/validation_exception_filter.ts
@@ -15,21 +15,36 @@ export class ValidationExceptionFilter implements ExceptionFilter {
     const response = ctx.getResponse<Response>();
     const request = ctx.getRequest<Request>();
 
-    console.log(exception.getResponse());
+    // console.log(exception.getResponse());qqq
     const exceptionResponse = exception.getResponse() as BadRequestResponse;
-    console.log('exceptionResponse:', exceptionResponse);
+    // console.log('exceptionResponse:', exceptionResponse);
     const messages = exceptionResponse?.message ?? [];
 
+    if (request.method !== 'GET') {
+      return response.status(400).json({
+        statusCode: 400,
+        message: messages,
+      });
+    }
     const hasParams = Object.keys(request.params || {}).length > 0;
     const hasQuery = Object.keys(request.query || {}).length > 0;
     // const hasBody = Object.keys(request.body || {}).length > 0;
 
     /**
-     * CASE 1: Param invalid → 404
+     * CASE 1: Query invalid → 200 []
      */
-    console.log('hasParams:', hasParams);
-    console.log('hasQuery:', hasQuery);
-    console.log('messages:', messages);
+    if (hasQuery) {
+      return response.status(200).json({
+        results: [],
+        total: 0,
+      });
+    }
+    /**
+     * CASE 2: Param invalid → 404
+     */
+    // console.log('hasParams:', hasParams);
+    // console.log('hasQuery:', hasQuery);
+    // console.log('messages:', messages);
     if (hasParams) {
       return response.status(404).json({
         statusCode: 404,
@@ -39,38 +54,11 @@ export class ValidationExceptionFilter implements ExceptionFilter {
     }
 
     /**
-     * CASE 2: Query invalid → 200 []
-     */
-    if (hasQuery) {
-      return response.status(200).json({
-        result: [],
-        total: 0,
-      });
-    }
-
-    /**
-     * CASE 3: Body invalid → giữ 400
+     * CASE 3: Body invalid → keep 400
      */
     return response.status(400).json({
       statusCode: 400,
       message: messages,
     });
   }
-
-  //   private isParamError(messages: string[]): boolean {
-  //     return messages.some(
-  //       (msg) =>
-  //         msg.toLowerCase().includes('uuid') ||
-  //         msg.toLowerCase().includes('param'),
-  //     );
-  //   }
-
-  //   private isQueryError(messages: string[]): boolean {
-  //     return messages.some(
-  //       (msg) =>
-  //         msg.toLowerCase().includes('page') ||
-  //         msg.toLowerCase().includes('limit') ||
-  //         msg.toLowerCase().includes('query'),
-  //     );
-  //   }
 }


### PR DESCRIPTION
## 🔗 Related Issue

Closes #107

## 🆕 What’s changed?
- Standardized response behavior for invalid inputs on GET endpoints
- Invalid query / filter format now returns 200 OK with empty results
- Invalid path param format now returns 404 Not Found
- Prevented validation / parsing details from being exposed to clients
- Eliminated inconsistent 400 / 500 responses for malformed GET requests
- Use @IsUUID instead of @IsString to ensure IDs are validated as proper UUIDs, preventing PostgreSQL from throwing 500 Internal Server Error for invalid UUID formats.

## 🎯 Purpose
- Improve UX by treating invalid GET inputs as “resource not found”
- Align API behavior with frontend expectations and response contracts
- Avoid leaking validation or internal error details to end users
- Ensure consistent and predictable responses for GET list and detail endpoints

## 📸 Screenshot at your local?
 
- Before  
<img width="2835" height="1777" alt="image" src="https://github.com/user-attachments/assets/412171c2-62dc-43af-b459-0d6a1acfdf80" />
- After 
<img width="2835" height="1777" alt="image" src="https://github.com/user-attachments/assets/381a757e-07c8-48c6-b537-dab7fc2469c2" />


## ⚠️ Breaking changes?

- [ ] Yes
- [x] No
