### PR TITLE
Feat/show notification check toxic

### DIFF
--- a/backend/prisma/migrations/20260213113831_capsole_project/migration.sql
+++ b/backend/prisma/migrations/20260213113831_capsole_project/migration.sql
@@ -1,0 +1,19 @@
+/*
+  Warnings:
+
+  - Added the required column `isToxic` to the `Feedbacks` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "NotificationType" ADD VALUE 'FEEDBACK_TOXIC_ACCEPTED';
+ALTER TYPE "NotificationType" ADD VALUE 'FEEDBACK_TOXIC_REJECTED';
+
+-- AlterTable
+ALTER TABLE "Feedbacks" ADD COLUMN     "isToxic" BOOLEAN NOT NULL;

--- a/backend/prisma/migrations/20260223032321_dev/migration.sql
+++ b/backend/prisma/migrations/20260223032321_dev/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Feedbacks" ALTER COLUMN "isToxic" SET DEFAULT false;

--- a/backend/prisma/migrations/20260303161143_init/migration.sql
+++ b/backend/prisma/migrations/20260303161143_init/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "FeedbackStatus" ADD VALUE 'TOXIC';

--- a/backend/prisma/migrations/20260308103447_dev/migration.sql
+++ b/backend/prisma/migrations/20260308103447_dev/migration.sql
@@ -1,0 +1,21 @@
+/*
+  Warnings:
+
+  - The values [TOXIC] on the enum `FeedbackStatus` will be removed. If these variants are still used in the database, this will fail.
+  - You are about to drop the column `isToxic` on the `Feedbacks` table. All the data in the column will be lost.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "FeedbackStatus_new" AS ENUM ('AI_REVIEWING', 'VIOLATED_CONTENT', 'AI_REVIEW_FAILED', 'PENDING', 'IN_PROGRESS', 'RESOLVED', 'REJECTED');
+ALTER TABLE "public"."Feedbacks" ALTER COLUMN "currentStatus" DROP DEFAULT;
+ALTER TABLE "Feedbacks" ALTER COLUMN "currentStatus" TYPE "FeedbackStatus_new" USING ("currentStatus"::text::"FeedbackStatus_new");
+ALTER TABLE "FeedbackStatusHistory" ALTER COLUMN "status" TYPE "FeedbackStatus_new" USING ("status"::text::"FeedbackStatus_new");
+ALTER TYPE "FeedbackStatus" RENAME TO "FeedbackStatus_old";
+ALTER TYPE "FeedbackStatus_new" RENAME TO "FeedbackStatus";
+DROP TYPE "public"."FeedbackStatus_old";
+ALTER TABLE "Feedbacks" ALTER COLUMN "currentStatus" SET DEFAULT 'PENDING';
+COMMIT;
+
+-- AlterTable
+ALTER TABLE "Feedbacks" DROP COLUMN "isToxic";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -56,6 +56,10 @@ enum NotificationType {
   // General/System notifications
   ADMIN_NOTIFICATION
   SYSTEM_ANNOUNCEMENT_NOTIFICATION
+  
+  // Feedback check toxic
+  FEEDBACK_TOXIC_ACCEPTED
+  FEEDBACK_TOXIC_REJECTED
 }
 
 enum FeedbackStatus {
@@ -154,6 +158,7 @@ model Feedbacks {
   departmentId    String            @db.Uuid
   categoryId      String            @db.Uuid
   createdAt       DateTime          @default(now())
+  isToxic         Boolean           
 
   user            Users             @relation(fields: [userId], references: [id])
   department      Departments       @relation(fields: [departmentId], references: [id])

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -158,7 +158,7 @@ model Feedbacks {
   departmentId    String            @db.Uuid
   categoryId      String            @db.Uuid
   createdAt       DateTime          @default(now())
-  isToxic         Boolean           
+  isToxic         Boolean           @default(false)
 
   user            Users             @relation(fields: [userId], references: [id])
   department      Departments       @relation(fields: [departmentId], references: [id])

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -67,6 +67,7 @@ enum FeedbackStatus {
   IN_PROGRESS
   RESOLVED
   REJECTED
+  TOXIC
 }
 
 enum ReportStatus {
@@ -158,7 +159,6 @@ model Feedbacks {
   departmentId    String            @db.Uuid
   categoryId      String            @db.Uuid
   createdAt       DateTime          @default(now())
-  isToxic         Boolean           @default(false)
 
   user            Users             @relation(fields: [userId], references: [id])
   department      Departments       @relation(fields: [departmentId], references: [id])

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -63,11 +63,13 @@ enum NotificationType {
 }
 
 enum FeedbackStatus {
+  AI_REVIEWING
+  VIOLATED_CONTENT
+  AI_REVIEW_FAILED
   PENDING
   IN_PROGRESS
   RESOLVED
   REJECTED
-  TOXIC
 }
 
 enum ReportStatus {

--- a/backend/src/modules/ai/ai.service.ts
+++ b/backend/src/modules/ai/ai.service.ts
@@ -1,9 +1,19 @@
 import { Injectable } from '@nestjs/common';
 import { GoogleGenAI } from '@google/genai';
 import { toxicityPrompt, toxicKeywords } from './prompts/toxicity.prompt';
+import { PrismaService } from '../prisma/prisma.service';
+import { FeedbackStatus } from '@prisma/client';
 @Injectable()
 export class AiService {
-  async checkToxicity(description: string): Promise<boolean> {
+  constructor(
+    private readonly prisma: PrismaService,
+  ) {}
+
+  async checkToxicity(
+    description: string,
+    data: any,
+    type: string,
+  ): Promise<boolean> {
     if (description) {
       // check keywords for toxicity
       const toxicKeywordsList = toxicKeywords;
@@ -14,7 +24,10 @@ export class AiService {
         }
       }
       const API_KEY = process.env.API_GEMINI_KEY || '';
-      if (!API_KEY) return false;
+      if (!API_KEY) {
+        await this.handleFaultGeminiEvent(data, type);
+        throw new Error('Google Gemini API key is not configured.');
+      }
       const genAI = new GoogleGenAI({ apiKey: API_KEY });
       const prompt = toxicityPrompt(description);
       const model = genAI.models.generateContent({
@@ -31,9 +44,90 @@ export class AiService {
           return true;
         }
       } catch {
+        await this.handleFaultGeminiEvent(data, type);
         throw new Error('Error parsing AI response for toxicity check.');
       }
     }
     return false;
+  }
+  async handleFaultGeminiEvent(data: any, type: string) {
+    if (type === 'create') {
+      await this.prisma.feedbacks.update({
+        where: { id: data.id },
+        data: {
+          currentStatus: FeedbackStatus.AI_REVIEW_FAILED,
+        },
+        include: {
+          department: {
+            select: { id: true, name: true },
+          },
+          category: {
+            select: { id: true, name: true },
+          },
+          statusHistory: {
+            select: {
+              status: true,
+              message: true,
+              note: true,
+              createdAt: true,
+            },
+            orderBy: { createdAt: 'asc' },
+          },
+          forumPost: {
+            select: { id: true },
+          },
+          forwardingLogs: {
+            select: {
+              id: true,
+              message: true,
+              createdAt: true,
+              note: true,
+              fromDepartment: { select: { id: true, name: true } },
+              toDepartment: { select: { id: true, name: true } },
+            },
+            orderBy: { createdAt: 'asc' },
+          },
+        },
+      });
+    } else if (type === 'update') {
+      const { feedbackId} = data;
+      await this.prisma.feedbacks.update({
+        where: { id: feedbackId },
+        data: {
+          currentStatus: FeedbackStatus.AI_REVIEW_FAILED,
+        },
+        include: {
+          department: {
+            select: { id: true, name: true },
+          },
+          category: {
+            select: { id: true, name: true },
+          },
+          statusHistory: {
+            select: {
+              status: true,
+              message: true,
+              note: true,
+              createdAt: true,
+            },
+            orderBy: { createdAt: 'asc' },
+          },
+          forumPost: {
+            select: { id: true },
+          },
+          forwardingLogs: {
+            select: {
+              id: true,
+              message: true,
+              createdAt: true,
+              note: true,
+              fromDepartment: { select: { id: true, name: true } },
+              toDepartment: { select: { id: true, name: true } },
+            },
+            orderBy: { createdAt: 'asc' },
+          },
+        },
+      });
+    }
   }
 }

--- a/backend/src/modules/feedbacks/dto/feedback-job-data.dto.ts
+++ b/backend/src/modules/feedbacks/dto/feedback-job-data.dto.ts
@@ -1,0 +1,15 @@
+import { CreateFeedbackDto } from "./create-feedback.dto";
+import type { ActiveUserData } from '../../auth/interfaces/active-user-data.interface';
+import { UpdateFeedbackDto } from "./update-feedback.dto";
+export type FeedbackJobData = | {
+    type: 'create';
+    dto: CreateFeedbackDto;
+    actor: ActiveUserData;
+}|{
+    type: 'update';
+    feedbackId: string;
+    updateFileAttachments: any,
+    updateData: any,
+    dto: UpdateFeedbackDto;
+    actor: ActiveUserData;
+}

--- a/backend/src/modules/feedbacks/dto/feedback-job-data.dto.ts
+++ b/backend/src/modules/feedbacks/dto/feedback-job-data.dto.ts
@@ -1,14 +1,12 @@
-import { CreateFeedbackDto } from "./create-feedback.dto";
 import type { ActiveUserData } from '../../auth/interfaces/active-user-data.interface';
 import { UpdateFeedbackDto } from "./update-feedback.dto";
 export type FeedbackJobData = | {
     type: 'create';
-    dto: CreateFeedbackDto;
+    feedback:any;
     actor: ActiveUserData;
 }|{
     type: 'update';
     feedbackId: string;
-    updateFileAttachments: any,
     updateData: any,
     dto: UpdateFeedbackDto;
     actor: ActiveUserData;

--- a/backend/src/modules/feedbacks/dto/feedback-job-data.dto.ts
+++ b/backend/src/modules/feedbacks/dto/feedback-job-data.dto.ts
@@ -1,13 +1,13 @@
 import type { ActiveUserData } from '../../auth/interfaces/active-user-data.interface';
+import { FeedbackDetail } from './feedback-response.dto';
 import { UpdateFeedbackDto } from "./update-feedback.dto";
 export type FeedbackJobData = | {
     type: 'create';
-    feedback:any;
+    feedback:FeedbackDetail;
     actor: ActiveUserData;
 }|{
     type: 'update';
     feedbackId: string;
-    updateData: any,
-    dto: UpdateFeedbackDto;
+    updateData: UpdateFeedbackDto,
     actor: ActiveUserData;
 }

--- a/backend/src/modules/feedbacks/events/feedback-created.event.ts
+++ b/backend/src/modules/feedbacks/events/feedback-created.event.ts
@@ -1,10 +1,13 @@
 // src/modules/feedbacks/events/feedback-created.event.ts
 
+import is from "zod/v4/locales/is.js";
+
 export class FeedbackCreatedEvent {
   feedbackId: string;
   userId: string;
   departmentId: string;
   subject: string;
+  isToxic: boolean;
 
   constructor(partial: Partial<FeedbackCreatedEvent>) {
     Object.assign(this, partial);

--- a/backend/src/modules/feedbacks/events/feedback-created.event.ts
+++ b/backend/src/modules/feedbacks/events/feedback-created.event.ts
@@ -1,6 +1,5 @@
 // src/modules/feedbacks/events/feedback-created.event.ts
 
-import is from "zod/v4/locales/is.js";
 
 export class FeedbackCreatedEvent {
   feedbackId: string;

--- a/backend/src/modules/feedbacks/feedbacks.controller.ts
+++ b/backend/src/modules/feedbacks/feedbacks.controller.ts
@@ -115,7 +115,7 @@ export class FeedbacksController {
     @Param() params: FeedbackParamDto,
     @Body() updateFeedbackDto: UpdateFeedbackDto,
     @ActiveUser() user: ActiveUserData,
-  ): Promise<FeedbackDetail> {
+  ) {
     return this.feedbacksService.updateFeedback(
       params,
       updateFeedbackDto,

--- a/backend/src/modules/feedbacks/feedbacks.processor.ts
+++ b/backend/src/modules/feedbacks/feedbacks.processor.ts
@@ -8,6 +8,7 @@ import { FeedbackStatus } from '@prisma/client';
 import type { ActiveUserData } from '../auth/interfaces/active-user-data.interface';
 import { FeedbackJobData } from './dto/feedback-job-data.dto';
 import { UpdateFeedbackDto } from './dto/update-feedback.dto';
+import { Prisma } from '@prisma/client';
 @Processor('feedback-toxic')
 export class FeedbackToxicProcessor extends WorkerHost {
   constructor(
@@ -17,6 +18,37 @@ export class FeedbackToxicProcessor extends WorkerHost {
   ) {
     super();
   }
+  private readonly defaultFeedbackInclude = {
+    department: {
+      select: { id: true, name: true },
+    },
+    category: {
+      select: { id: true, name: true },
+    },
+    statusHistory: {
+      select: {
+        status: true,
+        message: true,
+        note: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: Prisma.SortOrder.asc },
+    },
+    forumPost: {
+      select: { id: true },
+    },
+    forwardingLogs: {
+      select: {
+        id: true,
+        message: true,
+        createdAt: true,
+        note: true,
+        fromDepartment: { select: { id: true, name: true } },
+        toDepartment: { select: { id: true, name: true } },
+      },
+      orderBy: { createdAt: Prisma.SortOrder.asc },
+    },
+  };
   async process(job: Job<FeedbackJobData>): Promise<void> {
     const { type } = job.data;
     switch (type) {
@@ -31,249 +63,117 @@ export class FeedbackToxicProcessor extends WorkerHost {
         throw new UnrecoverableError(`Unsupported job type: ${type}`);
     }
   }
+  // Sử dụng chung hàm này cho cả create và update để tránh trùng lặp code
   async handleUpdateFeedback(data: {
     feedbackId: string;
     updateData: any;
     dto: UpdateFeedbackDto;
     actor: ActiveUserData;
   }) {
-    const { updateData, feedbackId, dto, actor } = data;
-    const isToxic = await this.aiService.checkToxicity(
-      dto.description || '',
-      data,
-      'update',
-    );
-    if (isToxic) {
-      await this.prisma.feedbacks.update({
-        where: { id: feedbackId },
-        data: {
-          currentStatus: FeedbackStatus.VIOLATED_CONTENT,
-        },
-        include: {
-          department: {
-            select: { id: true, name: true },
-          },
-          category: {
-            select: { id: true, name: true },
-          },
-          statusHistory: {
-            select: {
-              status: true,
-              message: true,
-              note: true,
-              createdAt: true,
-            },
-            orderBy: { createdAt: 'asc' },
-          },
-          forumPost: {
-            select: { id: true },
-          },
-          forwardingLogs: {
-            select: {
-              id: true,
-              message: true,
-              createdAt: true,
-              note: true,
-              fromDepartment: { select: { id: true, name: true } },
-              toDepartment: { select: { id: true, name: true } },
-            },
-            orderBy: { createdAt: 'asc' },
-          },
-        },
-      });
-      // Emit Event: Toxic Feedback Updated
-      const feedbackCreatedEvent = new FeedbackCreatedEvent({
-        feedbackId: feedbackId,
-        userId: actor.sub,
-        departmentId: updateData.departmentId,
-        subject: updateData.subject,
-        isToxic: true,
-      });
-      this.eventEmitter.emit('feedback.created', feedbackCreatedEvent);
-      throw new UnrecoverableError(
-        'Feedback description contains toxic content. Please modify and try again.',
-      );
-    } else {
-      await this.prisma.feedbacks.update({
-        where: { id: feedbackId },
-        data: {
-          currentStatus: FeedbackStatus.PENDING,
-        },
-        include: {
-          department: {
-            select: { id: true, name: true },
-          },
-          category: {
-            select: { id: true, name: true },
-          },
-          statusHistory: {
-            select: {
-              status: true,
-              message: true,
-              note: true,
-              createdAt: true,
-            },
-            orderBy: { createdAt: 'asc' },
-          },
-          forumPost: {
-            select: { id: true },
-          },
-          forwardingLogs: {
-            select: {
-              id: true,
-              message: true,
-              createdAt: true,
-              note: true,
-              fromDepartment: { select: { id: true, name: true } },
-              toDepartment: { select: { id: true, name: true } },
-            },
-            orderBy: { createdAt: 'asc' },
-          },
-        },
-      });
-      // Emit Event: Toxic Feedback Updated
-      const feedbackCreatedEvent = new FeedbackCreatedEvent({
-        feedbackId: feedbackId,
-        userId: actor.sub,
-        departmentId: updateData.departmentId,
-        subject: updateData.subject,
-        isToxic: false,
-      });
-      this.eventEmitter.emit('feedback.created', feedbackCreatedEvent);
-    }
+    await this.processToxicity({
+      feedbackId: data.feedbackId,
+      description: data.dto.description || '',
+      departmentId: data.updateData.departmentId,
+      subject: data.updateData.subject,
+      actorId: data.actor.sub,
+      aiDataContext: data,
+      jobType: 'update',
+    });
   }
   async handleCreateFeedback(data: { feedback: any; actor: ActiveUserData }) {
-    const { feedback, actor } = data;
+    await this.processToxicity({
+      feedbackId: data.feedback.id,
+      description: data.feedback.description,
+      departmentId: data.feedback.departmentId,
+      subject: data.feedback.subject,
+      actorId: data.actor.sub,
+      aiDataContext: data.feedback,
+      jobType: 'create',
+    });
+  }
+  private async processToxicity(params: {
+    feedbackId: string;
+    description: string;
+    departmentId: string;
+    subject: string;
+    actorId: string;
+    aiDataContext: any;
+    jobType: 'create' | 'update';
+  }) {
+    const {
+      feedbackId,
+      description,
+      departmentId,
+      subject,
+      actorId,
+      aiDataContext,
+      jobType,
+    } = params;
+
     const isToxic = await this.aiService.checkToxicity(
-      feedback.description,
-      feedback,
-      'create',
+      description,
+      aiDataContext,
+      jobType,
     );
+
+    await this.prisma.feedbacks.update({
+      where: { id: feedbackId },
+      data: {
+        currentStatus: isToxic
+          ? FeedbackStatus.VIOLATED_CONTENT
+          : FeedbackStatus.PENDING,
+      },
+      include: this.defaultFeedbackInclude,
+    });
+
+    this.eventEmitter.emit(
+      'feedback.created',
+      new FeedbackCreatedEvent({
+        feedbackId,
+        userId: actorId,
+        departmentId,
+        subject,
+        isToxic,
+      }),
+    );
+
+    // Throw error nếu có toxic
     if (isToxic) {
-      await this.prisma.feedbacks.update({
-        where: { id: feedback.id },
-        data: {
-          currentStatus: FeedbackStatus.VIOLATED_CONTENT,
-        },
-        include: {
-          department: {
-            select: { id: true, name: true },
-          },
-          category: {
-            select: { id: true, name: true },
-          },
-          statusHistory: {
-            select: {
-              status: true,
-              message: true,
-              note: true,
-              createdAt: true,
-            },
-            orderBy: { createdAt: 'asc' },
-          },
-          forumPost: {
-            select: { id: true },
-          },
-          forwardingLogs: {
-            select: {
-              id: true,
-              message: true,
-              createdAt: true,
-              note: true,
-              fromDepartment: { select: { id: true, name: true } },
-              toDepartment: { select: { id: true, name: true } },
-            },
-            orderBy: { createdAt: 'asc' },
-          },
-        },
-      });
-      // Emit Event: Toxic Feedback Created
-      const feedbackCreatedEvent = new FeedbackCreatedEvent({
-        feedbackId: feedback.id,
-        userId: actor.sub,
-        departmentId: feedback.departmentId,
-        subject: feedback.subject,
-        isToxic: true,
-      });
-      this.eventEmitter.emit('feedback.created', feedbackCreatedEvent);
       throw new UnrecoverableError(
         'Feedback description contains toxic content. Please modify and try again.',
       );
-    } else {
-      await this.prisma.feedbacks.update({
-        where: { id: feedback.id },
-        data: {
-          currentStatus: FeedbackStatus.PENDING,
-        },
-        include: {
-          department: {
-            select: { id: true, name: true },
-          },
-          category: {
-            select: { id: true, name: true },
-          },
-          statusHistory: {
-            select: {
-              status: true,
-              message: true,
-              note: true,
-              createdAt: true,
-            },
-            orderBy: { createdAt: 'asc' },
-          },
-          forumPost: {
-            select: { id: true },
-          },
-          forwardingLogs: {
-            select: {
-              id: true,
-              message: true,
-              createdAt: true,
-              note: true,
-              fromDepartment: { select: { id: true, name: true } },
-              toDepartment: { select: { id: true, name: true } },
-            },
-            orderBy: { createdAt: 'asc' },
-          },
-        },
-      });
-      // [New Logic] Emit Event: Feedback Created
-      // This allows the Notification module to handle notifications asynchronously without blocking this response.
-      const feedbackCreatedEvent = new FeedbackCreatedEvent({
-        feedbackId: feedback.id,
-        userId: actor.sub,
-        departmentId: feedback.departmentId,
-        subject: feedback.subject,
-        isToxic: false,
-      });
-      this.eventEmitter.emit('feedback.created', feedbackCreatedEvent);
     }
   }
+  // Xử lý khi job thất bại sau tất cả các lần thử
   @OnWorkerEvent('failed')
   async onFailed(job: Job, error: Error) {
-    if(job.attemptsMade >= (job.opts.attempts ?? 1)) {
+    let eventPayload: FeedbackCreatedEvent | null = null;
+    // Chỉ xử lý khi đã hết tất cả các lần thử
+    if (job.attemptsMade >= (job.opts.attempts ?? 1)) {
       if (job.data.type === 'create') {
         const { feedback, actor } = job.data;
-        // Emit event for new feedback with FAULT_GEMINI status
-        const feedbackCreatedEvent = new FeedbackCreatedEvent({
+        eventPayload = {
           feedbackId: feedback.id,
           userId: actor.sub,
           departmentId: feedback.departmentId,
           subject: feedback.subject,
           isToxic: true,
-        });
-        this.eventEmitter.emit('feedback.fault.api.gemini', feedbackCreatedEvent);
+        };
       } else if (job.data.type === 'update') {
         const { updateData, feedbackId, actor } = job.data;
-        // Emit event for new feedback with FAULT_GEMINI status
-        const feedbackCreatedEvent = new FeedbackCreatedEvent({
+        eventPayload = {
           feedbackId: feedbackId,
           userId: actor.sub,
           departmentId: updateData.departmentId,
           subject: updateData.subject,
           isToxic: true,
-        });
-        this.eventEmitter.emit('feedback.fault.api.gemini', feedbackCreatedEvent);
+        };
+      }
+      if (eventPayload) {
+        this.eventEmitter.emit(
+          'feedback.fault.api.gemini',
+          new FeedbackCreatedEvent(eventPayload),
+        );
       }
     }
   }

--- a/backend/src/modules/feedbacks/feedbacks.processor.ts
+++ b/backend/src/modules/feedbacks/feedbacks.processor.ts
@@ -1,4 +1,4 @@
-import { OnWorkerEvent, Processor, WorkerHost  } from '@nestjs/bullmq';
+import { OnWorkerEvent, Processor, WorkerHost } from '@nestjs/bullmq';
 import { Job, UnrecoverableError } from 'bullmq';
 import { AiService } from '../ai/ai.service';
 import { PrismaService } from '../prisma/prisma.service';
@@ -9,6 +9,7 @@ import type { ActiveUserData } from '../auth/interfaces/active-user-data.interfa
 import { FeedbackJobData } from './dto/feedback-job-data.dto';
 import { UpdateFeedbackDto } from './dto/update-feedback.dto';
 import { Prisma } from '@prisma/client';
+import { FeedbackDetail } from './dto';
 @Processor('feedback-toxic')
 export class FeedbackToxicProcessor extends WorkerHost {
   constructor(
@@ -66,25 +67,27 @@ export class FeedbackToxicProcessor extends WorkerHost {
   // Sử dụng chung hàm này cho cả create và update để tránh trùng lặp code
   async handleUpdateFeedback(data: {
     feedbackId: string;
-    updateData: any;
-    dto: UpdateFeedbackDto;
+    updateData: UpdateFeedbackDto;
     actor: ActiveUserData;
   }) {
     await this.processToxicity({
       feedbackId: data.feedbackId,
-      description: data.dto.description || '',
-      departmentId: data.updateData.departmentId,
-      subject: data.updateData.subject,
+      description: data.updateData.description || '',
+      departmentId: data.updateData.departmentId || '',
+      subject: data.updateData.subject || '',
       actorId: data.actor.sub,
       aiDataContext: data,
       jobType: 'update',
     });
   }
-  async handleCreateFeedback(data: { feedback: any; actor: ActiveUserData }) {
+  async handleCreateFeedback(data: {
+    feedback: FeedbackDetail;
+    actor: ActiveUserData;
+  }) {
     await this.processToxicity({
       feedbackId: data.feedback.id,
       description: data.feedback.description,
-      departmentId: data.feedback.departmentId,
+      departmentId: data.feedback.department.id,
       subject: data.feedback.subject,
       actorId: data.actor.sub,
       aiDataContext: data.feedback,
@@ -155,7 +158,7 @@ export class FeedbackToxicProcessor extends WorkerHost {
         eventPayload = {
           feedbackId: feedback.id,
           userId: actor.sub,
-          departmentId: feedback.departmentId,
+          departmentId: feedback.department.id,
           subject: feedback.subject,
           isToxic: true,
         };

--- a/backend/src/modules/feedbacks/feedbacks.processor.ts
+++ b/backend/src/modules/feedbacks/feedbacks.processor.ts
@@ -1,62 +1,54 @@
-import { Processor, WorkerHost } from '@nestjs/bullmq';
+import { OnWorkerEvent, Processor, WorkerHost  } from '@nestjs/bullmq';
 import { Job, UnrecoverableError } from 'bullmq';
 import { AiService } from '../ai/ai.service';
 import { PrismaService } from '../prisma/prisma.service';
-import { ForumService } from '../forum/forum.service';
-import { UploadsService } from '../uploads/uploads.service';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { FeedbackCreatedEvent } from './events/feedback-created.event';
-import { GenerateStatusUpdateMessage } from 'src/shared/helpers/feedback-message.helper';
-import { FileTargetType } from '@prisma/client';
-import { CreateFeedbackDto, FeedbackSummary} from './dto';
+import { FeedbackStatus } from '@prisma/client';
 import type { ActiveUserData } from '../auth/interfaces/active-user-data.interface';
 import { FeedbackJobData } from './dto/feedback-job-data.dto';
 import { UpdateFeedbackDto } from './dto/update-feedback.dto';
-import { mergeStatusAndForwardLogs } from 'src/shared/helpers/merge-forwarding_log-and-feedback_status_history';
-import { FeedbackDetail } from './dto';
 @Processor('feedback-toxic')
 export class FeedbackToxicProcessor extends WorkerHost {
   constructor(
     private readonly aiService: AiService,
     private readonly prisma: PrismaService,
-    private readonly forumService: ForumService,
-    private readonly uploadsService: UploadsService,
     private readonly eventEmitter: EventEmitter2,
   ) {
     super();
   }
-  async process(
-    job: Job<FeedbackJobData,FeedbackSummary>): Promise<FeedbackSummary|FeedbackDetail> {
-        const {type} = job.data;
-        switch (type) {
-        case 'create':
-          return this.handleCreateFeedback(job.data);
+  async process(job: Job<FeedbackJobData>): Promise<void> {
+    const { type } = job.data;
+    switch (type) {
+      case 'create':
+        await this.handleCreateFeedback(job.data);
+        break;
+      case 'update':
+        await this.handleUpdateFeedback(job.data);
+        break;
 
-        case 'update':
-          return this.handleUpdateFeedback(job.data);
-
-        default:
-          throw new UnrecoverableError(`Unsupported job type: ${type}`);
-  }
-        
+      default:
+        throw new UnrecoverableError(`Unsupported job type: ${type}`);
+    }
   }
   async handleUpdateFeedback(data: {
-  feedbackId: string;
-  updateFileAttachments: any,
-  updateData: any,
-  dto: UpdateFeedbackDto;
-  actor: ActiveUserData;
-  }): Promise<FeedbackDetail> {
-    const {updateData,updateFileAttachments,feedbackId, dto, actor } = data;
-    const isToxic = await this.aiService.checkToxicity(dto.description || '');
-    if(isToxic){
-      const updateDataNew = {
-        ...updateData,
-        currentStatus: 'TOXIC',
-      };
+    feedbackId: string;
+    updateData: any;
+    dto: UpdateFeedbackDto;
+    actor: ActiveUserData;
+  }) {
+    const { updateData, feedbackId, dto, actor } = data;
+    const isToxic = await this.aiService.checkToxicity(
+      dto.description || '',
+      data,
+      'update',
+    );
+    if (isToxic) {
       await this.prisma.feedbacks.update({
         where: { id: feedbackId },
-        data: updateDataNew,
+        data: {
+          currentStatus: FeedbackStatus.VIOLATED_CONTENT,
+        },
         include: {
           department: {
             select: { id: true, name: true },
@@ -101,15 +93,12 @@ export class FeedbackToxicProcessor extends WorkerHost {
       throw new UnrecoverableError(
         'Feedback description contains toxic content. Please modify and try again.',
       );
-    }
-    else{
-      const updateDataNew = {
-        ...updateData,
-        currentStatus: "PENDING",
-      };
-      const updateFeedback = await this.prisma.feedbacks.update({
+    } else {
+      await this.prisma.feedbacks.update({
         where: { id: feedbackId },
-        data: updateDataNew,
+        data: {
+          currentStatus: FeedbackStatus.PENDING,
+        },
         include: {
           department: {
             select: { id: true, name: true },
@@ -142,119 +131,112 @@ export class FeedbackToxicProcessor extends WorkerHost {
           },
         },
       });
-
-      const unifiedTimeline = mergeStatusAndForwardLogs({
-        statusHistory: updateFeedback.statusHistory,
-        forwardingLogs: updateFeedback.forwardingLogs.map((f) => ({
-          fromDept: f.fromDepartment,
-          toDept: f.toDepartment,
-          message: f.message,
-          note: f.note ?? null,
-          createdAt: f.createdAt,
-        })),
+      // Emit Event: Toxic Feedback Updated
+      const feedbackCreatedEvent = new FeedbackCreatedEvent({
+        feedbackId: feedbackId,
+        userId: actor.sub,
+        departmentId: updateData.departmentId,
+        subject: updateData.subject,
+        isToxic: false,
       });
-      return {
-        id: updateFeedback.id,
-        isPublic: updateFeedback.forumPost ? true : false,
-        subject: updateFeedback.subject,
-        description: updateFeedback.description,
-        location: updateFeedback.location ? updateFeedback.location : null,
-        currentStatus: updateFeedback.currentStatus,
-        isPrivate: updateFeedback.isPrivate,
-        createdAt: updateFeedback.createdAt.toISOString(),
-        department: {
-          id: updateFeedback.department.id,
-          name: updateFeedback.department.name,
-        },
-        category: {
-          id: updateFeedback.category.id,
-          name: updateFeedback.category.name,
-        },
-        statusHistory: unifiedTimeline,
-        fileAttachments: updateFileAttachments,
-      };
+      this.eventEmitter.emit('feedback.created', feedbackCreatedEvent);
     }
-       
-
   }
-  async handleCreateFeedback(data: {
-    dto: CreateFeedbackDto;
-    actor: ActiveUserData;
-  }): Promise<FeedbackSummary> {
-     const { dto, actor } = data;
-        const { fileAttachments, ...feedbackData } = dto;
-        const isToxic = await this.aiService.checkToxicity(dto.description);
-        if (isToxic) {
-            const feedback = await this.prisma.feedbacks.create({
-            data: {
-                subject: feedbackData.subject,
-                description: feedbackData.description,
-                location: feedbackData.location,
-                isPrivate: dto.isAnonymous ? true : false,
-                departmentId: feedbackData.departmentId,
-                categoryId: feedbackData.categoryId,
-                currentStatus: 'TOXIC',
-                userId: actor.sub,
-            },
-            include: {
-                department: true,
-                category: true,
-            },
-            });
-            // Emit Event: Toxic Feedback Created
-            const feedbackCreatedEvent = new FeedbackCreatedEvent({
-              feedbackId: feedback.id,
-              userId: actor.sub,
-              departmentId: feedback.departmentId,
-              subject: feedback.subject,
-              isToxic: true,
-            });
-            this.eventEmitter.emit('feedback.created', feedbackCreatedEvent);
-            throw new UnrecoverableError(
-                'Feedback description contains toxic content. Please modify and try again.',
-            );
-        }
-        else{
-           // Create new feedback
-            const feedback = await this.prisma.feedbacks.create({
-            data: {
-                subject: feedbackData.subject,
-                description: feedbackData.description,
-                location: feedbackData.location,
-                isPrivate: dto.isAnonymous ? true : false,
-                departmentId: feedbackData.departmentId,
-                categoryId: feedbackData.categoryId,
-                userId: actor.sub,
-            },
-            include: {
-                department: true,
-                category: true,
-            },
-            });
-            if (dto.isPublic) {
-            await this.forumService.createForumPost(feedback.id, actor);
-            }
-
-      // Create attachments using UploadsService
-      if (fileAttachments && fileAttachments.length > 0) {
-        await this.uploadsService.updateAttachmentsForTarget(
-          feedback.id,
-          FileTargetType.FEEDBACK,
-          fileAttachments,
-        );
-      }
-
-      await this.prisma.feedbackStatusHistory.create({
+  async handleCreateFeedback(data: { feedback: any; actor: ActiveUserData }) {
+    const { feedback, actor } = data;
+    const isToxic = await this.aiService.checkToxicity(
+      feedback.description,
+      feedback,
+      'create',
+    );
+    if (isToxic) {
+      await this.prisma.feedbacks.update({
+        where: { id: feedback.id },
         data: {
-          feedbackId: feedback.id,
-          status: 'PENDING',
-          message: GenerateStatusUpdateMessage(
-            feedback.department.name,
-            'PENDING',
-          ),
+          currentStatus: FeedbackStatus.VIOLATED_CONTENT,
+        },
+        include: {
+          department: {
+            select: { id: true, name: true },
+          },
+          category: {
+            select: { id: true, name: true },
+          },
+          statusHistory: {
+            select: {
+              status: true,
+              message: true,
+              note: true,
+              createdAt: true,
+            },
+            orderBy: { createdAt: 'asc' },
+          },
+          forumPost: {
+            select: { id: true },
+          },
+          forwardingLogs: {
+            select: {
+              id: true,
+              message: true,
+              createdAt: true,
+              note: true,
+              fromDepartment: { select: { id: true, name: true } },
+              toDepartment: { select: { id: true, name: true } },
+            },
+            orderBy: { createdAt: 'asc' },
+          },
         },
       });
-
+      // Emit Event: Toxic Feedback Created
+      const feedbackCreatedEvent = new FeedbackCreatedEvent({
+        feedbackId: feedback.id,
+        userId: actor.sub,
+        departmentId: feedback.departmentId,
+        subject: feedback.subject,
+        isToxic: true,
+      });
+      this.eventEmitter.emit('feedback.created', feedbackCreatedEvent);
+      throw new UnrecoverableError(
+        'Feedback description contains toxic content. Please modify and try again.',
+      );
+    } else {
+      await this.prisma.feedbacks.update({
+        where: { id: feedback.id },
+        data: {
+          currentStatus: FeedbackStatus.PENDING,
+        },
+        include: {
+          department: {
+            select: { id: true, name: true },
+          },
+          category: {
+            select: { id: true, name: true },
+          },
+          statusHistory: {
+            select: {
+              status: true,
+              message: true,
+              note: true,
+              createdAt: true,
+            },
+            orderBy: { createdAt: 'asc' },
+          },
+          forumPost: {
+            select: { id: true },
+          },
+          forwardingLogs: {
+            select: {
+              id: true,
+              message: true,
+              createdAt: true,
+              note: true,
+              fromDepartment: { select: { id: true, name: true } },
+              toDepartment: { select: { id: true, name: true } },
+            },
+            orderBy: { createdAt: 'asc' },
+          },
+        },
+      });
       // [New Logic] Emit Event: Feedback Created
       // This allows the Notification module to handle notifications asynchronously without blocking this response.
       const feedbackCreatedEvent = new FeedbackCreatedEvent({
@@ -265,25 +247,34 @@ export class FeedbackToxicProcessor extends WorkerHost {
         isToxic: false,
       });
       this.eventEmitter.emit('feedback.created', feedbackCreatedEvent);
-
-      // Return summary
-      return {
-        id: feedback.id,
-        subject: feedback.subject,
-        location: feedback.location ? feedback.location : null,
-        currentStatus: feedback.currentStatus,
-        isPrivate: feedback.isPrivate,
-        department: {
-          id: feedback.department.id,
-          name: feedback.department.name,
-        },
-        category: {
-          id: feedback.category.id,
-          name: feedback.category.name,
-        },
-        createdAt: feedback.createdAt.toISOString(),
-      };
+    }
+  }
+  @OnWorkerEvent('failed')
+  async onFailed(job: Job, error: Error) {
+    if(job.attemptsMade >= (job.opts.attempts ?? 1)) {
+      if (job.data.type === 'create') {
+        const { feedback, actor } = job.data;
+        // Emit event for new feedback with FAULT_GEMINI status
+        const feedbackCreatedEvent = new FeedbackCreatedEvent({
+          feedbackId: feedback.id,
+          userId: actor.sub,
+          departmentId: feedback.departmentId,
+          subject: feedback.subject,
+          isToxic: true,
+        });
+        this.eventEmitter.emit('feedback.fault.api.gemini', feedbackCreatedEvent);
+      } else if (job.data.type === 'update') {
+        const { updateData, feedbackId, actor } = job.data;
+        // Emit event for new feedback with FAULT_GEMINI status
+        const feedbackCreatedEvent = new FeedbackCreatedEvent({
+          feedbackId: feedbackId,
+          userId: actor.sub,
+          departmentId: updateData.departmentId,
+          subject: updateData.subject,
+          isToxic: true,
+        });
+        this.eventEmitter.emit('feedback.fault.api.gemini', feedbackCreatedEvent);
       }
-    
+    }
   }
 }

--- a/backend/src/modules/feedbacks/feedbacks.processor.ts
+++ b/backend/src/modules/feedbacks/feedbacks.processor.ts
@@ -10,6 +10,10 @@ import { GenerateStatusUpdateMessage } from 'src/shared/helpers/feedback-message
 import { FileTargetType } from '@prisma/client';
 import { CreateFeedbackDto, FeedbackSummary} from './dto';
 import type { ActiveUserData } from '../auth/interfaces/active-user-data.interface';
+import { FeedbackJobData } from './dto/feedback-job-data.dto';
+import { UpdateFeedbackDto } from './dto/update-feedback.dto';
+import { mergeStatusAndForwardLogs } from 'src/shared/helpers/merge-forwarding_log-and-feedback_status_history';
+import { FeedbackDetail } from './dto';
 @Processor('feedback-toxic')
 export class FeedbackToxicProcessor extends WorkerHost {
   constructor(
@@ -22,12 +26,162 @@ export class FeedbackToxicProcessor extends WorkerHost {
     super();
   }
   async process(
-    job: Job<
-      {
-        dto: CreateFeedbackDto;
-        actor: ActiveUserData;
-    },FeedbackSummary>): Promise<FeedbackSummary> {
-        const { dto, actor } = job.data;
+    job: Job<FeedbackJobData,FeedbackSummary>): Promise<FeedbackSummary|FeedbackDetail> {
+        const {type} = job.data;
+        switch (type) {
+        case 'create':
+          return this.handleCreateFeedback(job.data);
+
+        case 'update':
+          return this.handleUpdateFeedback(job.data);
+
+        default:
+          throw new UnrecoverableError(`Unsupported job type: ${type}`);
+  }
+        
+  }
+  async handleUpdateFeedback(data: {
+  feedbackId: string;
+  updateFileAttachments: any,
+  updateData: any,
+  dto: UpdateFeedbackDto;
+  actor: ActiveUserData;
+  }): Promise<FeedbackDetail> {
+    const {updateData,updateFileAttachments,feedbackId, dto, actor } = data;
+    const isToxic = await this.aiService.checkToxicity(dto.description || '');
+    if(isToxic){
+      const updateDataNew = {
+        ...updateData,
+        currentStatus: 'TOXIC',
+      };
+      await this.prisma.feedbacks.update({
+        where: { id: feedbackId },
+        data: updateDataNew,
+        include: {
+          department: {
+            select: { id: true, name: true },
+          },
+          category: {
+            select: { id: true, name: true },
+          },
+          statusHistory: {
+            select: {
+              status: true,
+              message: true,
+              note: true,
+              createdAt: true,
+            },
+            orderBy: { createdAt: 'asc' },
+          },
+          forumPost: {
+            select: { id: true },
+          },
+          forwardingLogs: {
+            select: {
+              id: true,
+              message: true,
+              createdAt: true,
+              note: true,
+              fromDepartment: { select: { id: true, name: true } },
+              toDepartment: { select: { id: true, name: true } },
+            },
+            orderBy: { createdAt: 'asc' },
+          },
+        },
+      });
+      // Emit Event: Toxic Feedback Updated
+      const feedbackCreatedEvent = new FeedbackCreatedEvent({
+        feedbackId: feedbackId,
+        userId: actor.sub,
+        departmentId: updateData.departmentId,
+        subject: updateData.subject,
+        isToxic: true,
+      });
+      this.eventEmitter.emit('feedback.created', feedbackCreatedEvent);
+      throw new UnrecoverableError(
+        'Feedback description contains toxic content. Please modify and try again.',
+      );
+    }
+    else{
+      const updateDataNew = {
+        ...updateData,
+        currentStatus: "PENDING",
+      };
+      const updateFeedback = await this.prisma.feedbacks.update({
+        where: { id: feedbackId },
+        data: updateDataNew,
+        include: {
+          department: {
+            select: { id: true, name: true },
+          },
+          category: {
+            select: { id: true, name: true },
+          },
+          statusHistory: {
+            select: {
+              status: true,
+              message: true,
+              note: true,
+              createdAt: true,
+            },
+            orderBy: { createdAt: 'asc' },
+          },
+          forumPost: {
+            select: { id: true },
+          },
+          forwardingLogs: {
+            select: {
+              id: true,
+              message: true,
+              createdAt: true,
+              note: true,
+              fromDepartment: { select: { id: true, name: true } },
+              toDepartment: { select: { id: true, name: true } },
+            },
+            orderBy: { createdAt: 'asc' },
+          },
+        },
+      });
+
+      const unifiedTimeline = mergeStatusAndForwardLogs({
+        statusHistory: updateFeedback.statusHistory,
+        forwardingLogs: updateFeedback.forwardingLogs.map((f) => ({
+          fromDept: f.fromDepartment,
+          toDept: f.toDepartment,
+          message: f.message,
+          note: f.note ?? null,
+          createdAt: f.createdAt,
+        })),
+      });
+      return {
+        id: updateFeedback.id,
+        isPublic: updateFeedback.forumPost ? true : false,
+        subject: updateFeedback.subject,
+        description: updateFeedback.description,
+        location: updateFeedback.location ? updateFeedback.location : null,
+        currentStatus: updateFeedback.currentStatus,
+        isPrivate: updateFeedback.isPrivate,
+        createdAt: updateFeedback.createdAt.toISOString(),
+        department: {
+          id: updateFeedback.department.id,
+          name: updateFeedback.department.name,
+        },
+        category: {
+          id: updateFeedback.category.id,
+          name: updateFeedback.category.name,
+        },
+        statusHistory: unifiedTimeline,
+        fileAttachments: updateFileAttachments,
+      };
+    }
+       
+
+  }
+  async handleCreateFeedback(data: {
+    dto: CreateFeedbackDto;
+    actor: ActiveUserData;
+  }): Promise<FeedbackSummary> {
+     const { dto, actor } = data;
         const { fileAttachments, ...feedbackData } = dto;
         const isToxic = await this.aiService.checkToxicity(dto.description);
         if (isToxic) {
@@ -39,8 +193,8 @@ export class FeedbackToxicProcessor extends WorkerHost {
                 isPrivate: dto.isAnonymous ? true : false,
                 departmentId: feedbackData.departmentId,
                 categoryId: feedbackData.categoryId,
+                currentStatus: 'TOXIC',
                 userId: actor.sub,
-                isToxic: true,
             },
             include: {
                 department: true,
@@ -71,7 +225,6 @@ export class FeedbackToxicProcessor extends WorkerHost {
                 departmentId: feedbackData.departmentId,
                 categoryId: feedbackData.categoryId,
                 userId: actor.sub,
-                isToxic: false,
             },
             include: {
                 department: true,
@@ -130,6 +283,7 @@ export class FeedbackToxicProcessor extends WorkerHost {
         },
         createdAt: feedback.createdAt.toISOString(),
       };
-    }
+      }
+    
   }
 }

--- a/backend/src/modules/feedbacks/feedbacks.service.ts
+++ b/backend/src/modules/feedbacks/feedbacks.service.ts
@@ -10,6 +10,7 @@ import {
   QueryFeedbacksDto,
   FeedbackDetail,
   FeedbackParamDto,
+  FeedbackSummary,
 } from './dto';
 import { CreateFeedbackDto } from './dto/create-feedback.dto';
 import { UpdateFeedbackDto } from './dto/update-feedback.dto';
@@ -19,6 +20,7 @@ import { ForumService } from '../forum/forum.service';
 import { mergeStatusAndForwardLogs } from 'src/shared/helpers/merge-forwarding_log-and-feedback_status_history';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
+import { GenerateStatusUpdateMessage } from 'src/shared/helpers/feedback-message.helper';
 @Injectable()
 export class FeedbacksService {
   constructor(
@@ -203,7 +205,7 @@ export class FeedbacksService {
     params: FeedbackParamDto,
     dto: UpdateFeedbackDto,
     actor: ActiveUserData,
-  ) {
+  ) : Promise<FeedbackDetail> {
     const { feedbackId } = params;
 
     const feedback = await this.prisma.feedbacks.findUnique({
@@ -217,9 +219,9 @@ export class FeedbacksService {
       throw new NotFoundException(`Feedback with ID ${feedbackId} not found.`);
     }
 
-    if (feedback.currentStatus !== FeedbackStatus.PENDING && feedback.currentStatus !== FeedbackStatus.TOXIC) {
+    if (feedback.currentStatus !== FeedbackStatus.PENDING && feedback.currentStatus !== FeedbackStatus.VIOLATED_CONTENT && feedback.currentStatus !== FeedbackStatus.AI_REVIEW_FAILED) {
       throw new ForbiddenException(
-        'Feedback can only be updated when in PENDING or TOXIC status.',
+        'Feedback can only be updated when in PENDING, VIOLATED_CONTENT, or AI_REVIEW_FAILED status.',
       );
     }
     if (dto.isAnonymous === true && dto.isPublic === true) {
@@ -271,24 +273,91 @@ export class FeedbacksService {
         FileTargetType.FEEDBACK,
         dto.fileAttachments ?? [],
       );
-    const job = await this.feedbackToxicQueue.add(
+
+    const updateDataNew = {
+      ...updateData,
+      currentStatus: FeedbackStatus.AI_REVIEWING,
+    };
+
+    const updateFeedback = await this.prisma.feedbacks.update({
+      where: { id: feedbackId },
+      data: updateDataNew,
+      include: {
+        department: {
+          select: { id: true, name: true },
+        },
+        category: {
+          select: { id: true, name: true },
+        },
+        statusHistory: {
+          select: {
+            status: true,
+            message: true,
+            note: true,
+            createdAt: true,
+          },
+          orderBy: { createdAt: 'asc' },
+        },
+        forumPost: {
+          select: { id: true },
+        },
+        forwardingLogs: {
+          select: {
+            id: true,
+            message: true,
+            createdAt: true,
+            note: true,
+            fromDepartment: { select: { id: true, name: true } },
+            toDepartment: { select: { id: true, name: true } },
+          },
+          orderBy: { createdAt: 'asc' },
+        },
+      },
+    });
+
+    const unifiedTimeline = mergeStatusAndForwardLogs({
+      statusHistory: updateFeedback.statusHistory,
+      forwardingLogs: updateFeedback.forwardingLogs.map((f) => ({
+        fromDept: f.fromDepartment,
+        toDept: f.toDepartment,
+        message: f.message,
+        note: f.note ?? null,
+        createdAt: f.createdAt,
+      })),
+    });
+    await this.feedbackToxicQueue.add(
       'feedbackToxicItem',
       {
         type: 'update',
         feedbackId: feedbackId,
-        updateFileAttachments: updateFileAttachments,
         updateData: updateData,
         dto: dto,
         actor: actor,
       },
       {
-        attempts: 3, 
-        backoff: 5000, 
-      }
+        attempts: 3,
+        backoff: 5000,
+      },
     );
     return {
-      jobId: job.id,   
-      status: 'PENDING',
+      id: updateFeedback.id,
+      isPublic: updateFeedback.forumPost ? true : false,
+      subject: updateFeedback.subject,
+      description: updateFeedback.description,
+      location: updateFeedback.location ? updateFeedback.location : null,
+      currentStatus: updateFeedback.currentStatus,
+      isPrivate: updateFeedback.isPrivate,
+      createdAt: updateFeedback.createdAt.toISOString(),
+      department: {
+        id: updateFeedback.department.id,
+        name: updateFeedback.department.name,
+      },
+      category: {
+        id: updateFeedback.category.id,
+        name: updateFeedback.category.name,
+      },
+      statusHistory: unifiedTimeline,
+      fileAttachments: updateFileAttachments,
     };
   }
 
@@ -306,9 +375,9 @@ export class FeedbacksService {
       throw new NotFoundException(`Feedback with ID ${feedbackId} not found.`);
     }
 
-    if (feedback.currentStatus !== FeedbackStatus.PENDING) {
+    if (feedback.currentStatus !== FeedbackStatus.PENDING && feedback.currentStatus !== FeedbackStatus.VIOLATED_CONTENT && feedback.currentStatus !== FeedbackStatus.AI_REVIEW_FAILED) {
       throw new ForbiddenException(
-        'Feedback can only be deleted when in PENDING status.',
+        'Feedback can only be deleted when in PENDING, VIOLATED_CONTENT, or AI_REVIEW_FAILED status.',
       );
     }
 
@@ -322,7 +391,8 @@ export class FeedbacksService {
     });
   }
 
-  async createFeedback(dto: CreateFeedbackDto, actor: ActiveUserData) {
+  async createFeedback(dto: CreateFeedbackDto, actor: ActiveUserData) : Promise<FeedbackSummary> {
+    
     const [department, category] = await Promise.all([
       this.prisma.departments.findUnique({
         where: { id: dto.departmentId },
@@ -348,22 +418,75 @@ export class FeedbacksService {
         'You cannot create feedback to an inactive department.',
       );
     }
+    const { fileAttachments, ...feedbackData } = dto;
+    // Create new feedback
+    const feedback = await this.prisma.feedbacks.create({
+      data: {
+        subject: feedbackData.subject,
+        description: feedbackData.description,
+        location: feedbackData.location,
+        isPrivate: dto.isAnonymous ? true : false,
+        departmentId: feedbackData.departmentId,
+        categoryId: feedbackData.categoryId,
+        userId: actor.sub,
+        currentStatus: FeedbackStatus.AI_REVIEWING,
+      },
+      include: {
+        department: true,
+        category: true,
+      },
+    });
+    if (dto.isPublic) {
+      await this.forumService.createForumPost(feedback.id, actor);
+    }
 
-    const job = await this.feedbackToxicQueue.add(
+    // Create attachments using UploadsService
+    if (fileAttachments && fileAttachments.length > 0) {
+      await this.uploadsService.updateAttachmentsForTarget(
+        feedback.id,
+        FileTargetType.FEEDBACK,
+        fileAttachments,
+      );
+    }
+
+    await this.prisma.feedbackStatusHistory.create({
+      data: {
+        feedbackId: feedback.id,
+        status: 'PENDING',
+        message: GenerateStatusUpdateMessage(
+          feedback.department.name,
+          'PENDING',
+        ),
+      },
+    });
+
+    await this.feedbackToxicQueue.add(
       'feedbackToxicItem',
       {
         type: 'create',
-        dto: dto,
-        actor: actor,
+        feedback:feedback,
+        actor:actor,
       },
       {
-        attempts: 3, 
-        backoff: 5000, 
-      }
+        attempts: 3,
+        backoff: 5000,
+      },
     );
     return {
-      jobId: job.id,   
-      status: 'PENDING',
+      id: feedback.id,
+      subject: feedback.subject,
+      location: feedback.location ? feedback.location : null,
+      currentStatus: feedback.currentStatus,
+      isPrivate: feedback.isPrivate,
+      department: {
+        id: feedback.department.id,
+        name: feedback.department.name,
+      },
+      category: {
+        id: feedback.category.id,
+        name: feedback.category.name,
+      },
+      createdAt: feedback.createdAt.toISOString(),
     };
   }
   async getToxicJobStatus(jobId: string) {

--- a/backend/src/modules/feedbacks/feedbacks.service.ts
+++ b/backend/src/modules/feedbacks/feedbacks.service.ts
@@ -203,7 +203,7 @@ export class FeedbacksService {
     params: FeedbackParamDto,
     dto: UpdateFeedbackDto,
     actor: ActiveUserData,
-  ): Promise<FeedbackDetail> {
+  ) {
     const { feedbackId } = params;
 
     const feedback = await this.prisma.feedbacks.findUnique({
@@ -217,9 +217,9 @@ export class FeedbacksService {
       throw new NotFoundException(`Feedback with ID ${feedbackId} not found.`);
     }
 
-    if (feedback.currentStatus !== FeedbackStatus.PENDING) {
+    if (feedback.currentStatus !== FeedbackStatus.PENDING && feedback.currentStatus !== FeedbackStatus.TOXIC) {
       throw new ForbiddenException(
-        'Feedback can only be updated when in PENDING status.',
+        'Feedback can only be updated when in PENDING or TOXIC status.',
       );
     }
     if (dto.isAnonymous === true && dto.isPublic === true) {
@@ -271,72 +271,24 @@ export class FeedbacksService {
         FileTargetType.FEEDBACK,
         dto.fileAttachments ?? [],
       );
-
-    const updateFeedback = await this.prisma.feedbacks.update({
-      where: { id: feedbackId },
-      data: updateData,
-      include: {
-        department: {
-          select: { id: true, name: true },
-        },
-        category: {
-          select: { id: true, name: true },
-        },
-        statusHistory: {
-          select: {
-            status: true,
-            message: true,
-            note: true,
-            createdAt: true,
-          },
-          orderBy: { createdAt: 'asc' },
-        },
-        forumPost: {
-          select: { id: true },
-        },
-        forwardingLogs: {
-          select: {
-            id: true,
-            message: true,
-            createdAt: true,
-            note: true,
-            fromDepartment: { select: { id: true, name: true } },
-            toDepartment: { select: { id: true, name: true } },
-          },
-          orderBy: { createdAt: 'asc' },
-        },
+    const job = await this.feedbackToxicQueue.add(
+      'feedbackToxicItem',
+      {
+        type: 'update',
+        feedbackId: feedbackId,
+        updateFileAttachments: updateFileAttachments,
+        updateData: updateData,
+        dto: dto,
+        actor: actor,
       },
-    });
-
-    const unifiedTimeline = mergeStatusAndForwardLogs({
-      statusHistory: updateFeedback.statusHistory,
-      forwardingLogs: updateFeedback.forwardingLogs.map((f) => ({
-        fromDept: f.fromDepartment,
-        toDept: f.toDepartment,
-        message: f.message,
-        note: f.note ?? null,
-        createdAt: f.createdAt,
-      })),
-    });
+      {
+        attempts: 3, 
+        backoff: 5000, 
+      }
+    );
     return {
-      id: updateFeedback.id,
-      isPublic: updateFeedback.forumPost ? true : false,
-      subject: updateFeedback.subject,
-      description: updateFeedback.description,
-      location: updateFeedback.location ? updateFeedback.location : null,
-      currentStatus: updateFeedback.currentStatus,
-      isPrivate: updateFeedback.isPrivate,
-      createdAt: updateFeedback.createdAt.toISOString(),
-      department: {
-        id: updateFeedback.department.id,
-        name: updateFeedback.department.name,
-      },
-      category: {
-        id: updateFeedback.category.id,
-        name: updateFeedback.category.name,
-      },
-      statusHistory: unifiedTimeline,
-      fileAttachments: updateFileAttachments,
+      jobId: job.id,   
+      status: 'PENDING',
     };
   }
 
@@ -400,6 +352,7 @@ export class FeedbacksService {
     const job = await this.feedbackToxicQueue.add(
       'feedbackToxicItem',
       {
+        type: 'create',
         dto: dto,
         actor: actor,
       },

--- a/backend/src/modules/notifications/listeners/notification.listener.ts
+++ b/backend/src/modules/notifications/listeners/notification.listener.ts
@@ -45,6 +45,9 @@ export class NotificationEventListener {
 
       // 2. Notify the Department Staff (The specific logic you requested)
       await this.notifyDepartmentStaff(payload);
+
+      // 3. Notify Student about Toxicity Check
+      await this.notifyFeedbackCheckToxicity(payload);
     } catch (error) {
       this.logger.error(
         `[Notification] Failed to create notifications for feedback ${payload.feedbackId}`,
@@ -557,5 +560,24 @@ export class NotificationEventListener {
         // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         throw new Error(`Invalid target type: ${targetType}`);
     }
+  }
+
+  private async notifyFeedbackCheckToxicity(payload: FeedbackCreatedEvent) {
+
+    let content = `Góp ý "${payload.subject}" của bạn đã được xác định là phù hợp với quy định cộng đồng. Cảm ơn bạn đã đóng góp ý kiến!`;
+    let type:NotificationType = NotificationType.FEEDBACK_TOXIC_ACCEPTED;
+    if (payload.isToxic) {
+      content = `Góp ý "${payload.subject}" của bạn đã được xác định là có nội dung không phù hợp và vi phạm quy định cộng đồng. Vui lòng chỉnh sửa và gửi lại góp ý.`;
+      type = NotificationType.FEEDBACK_TOXIC_REJECTED;
+    }
+    await this.notificationsService.createNotifications({
+      userIds: [payload.userId],
+      content: content,
+      type: type,
+      targetId: payload.feedbackId,
+      title: payload.subject,
+    });
+
+    
   }
 }

--- a/backend/src/modules/notifications/listeners/notification.listener.ts
+++ b/backend/src/modules/notifications/listeners/notification.listener.ts
@@ -438,6 +438,27 @@ export class NotificationEventListener {
     }
   }
 
+  // ============================================
+  // NEW HANDLER: FEEDBACK FAULT API GEMINI
+  // ============================================
+  @OnEvent('feedback.fault.api.gemini', { async: true })
+  async handleFeedbackFaultAPIGemini(payload: FeedbackCreatedEvent) {
+    this.logger.log(
+      `[Notification] Processing Gemini API fault for Feedback ID: ${payload.feedbackId}`,
+    );
+    try {
+      // 1. Notify the Student (Confirmation that feedback was sent)
+      await this.notifyStudent(payload);
+      // 2. fault system issue when checking toxicity with Gemini API      
+      await this.notifyFeedbackFaultAPIGemini(payload);
+    } catch (error) {
+      this.logger.error(
+        `Failed to notify Gemini API fault for feedback ${payload.feedbackId}`,
+        error.stack,
+      );
+    }
+  }
+
   // ==========================================
   // HELPER METHODS
   // ==========================================
@@ -563,11 +584,10 @@ export class NotificationEventListener {
   }
 
   private async notifyFeedbackCheckToxicity(payload: FeedbackCreatedEvent) {
-
-    let content = `Góp ý "${payload.subject}" của bạn đã được xác định là phù hợp với quy định cộng đồng. Cảm ơn bạn đã đóng góp ý kiến!`;
+    let content = `Góp ý "${payload.subject}" của bạn đã được hệ thống kiểm tra và xác nhận là phù hợp với quy định của nhà trường. Cảm ơn bạn đã dành thời gian đóng góp ý kiến nhằm cải thiện môi trường học tập và hoạt động của trường.`;
     let type:NotificationType = NotificationType.FEEDBACK_TOXIC_ACCEPTED;
     if (payload.isToxic) {
-      content = `Góp ý "${payload.subject}" của bạn đã được xác định là có nội dung không phù hợp và vi phạm quy định cộng đồng. Vui lòng chỉnh sửa và gửi lại góp ý.`;
+      content = `Góp ý "${payload.subject}" của bạn đã được hệ thống kiểm tra và phát hiện có nội dung chưa phù hợp với quy định của nhà trường. Vui lòng chỉnh sửa lại nội dung và gửi lại để góp ý được xem xét. Xin cảm ơn sự hợp tác của bạn.`;
       type = NotificationType.FEEDBACK_TOXIC_REJECTED;
     }
     await this.notificationsService.createNotifications({
@@ -579,5 +599,15 @@ export class NotificationEventListener {
     });
 
     
+  }
+  private async notifyFeedbackFaultAPIGemini(payload: FeedbackCreatedEvent) {
+    const content = `Góp ý "${payload.subject}" của bạn đã được gửi thành công. Tuy nhiên, hệ thống đang gặp sự cố khi kiểm tra nội dung bằng AI. Chúng tôi sẽ tiến hành kiểm tra lại trong thời gian sớm nhất. Nếu vấn đề vẫn tiếp diễn, vui lòng liên hệ bộ phận hỗ trợ.`;
+    await this.notificationsService.createNotifications({
+      userIds: [payload.userId],
+      content: content,
+      type: NotificationType.SYSTEM_ANNOUNCEMENT_NOTIFICATION,
+      targetId: payload.feedbackId,
+      title: payload.subject,
+    });
   }
 }


### PR DESCRIPTION
## 🔗 Related Issue

Closes #

## 🆕 What’s changed?

-

## 🎯 Purpose

- Save feedback in database and create notification when feedback is checked toxic successfully or unsuccessfully

## 📸 Screenshot at your local?
Create feedback with toxic 

<img width="1440" height="622" alt="image" src="https://github.com/user-attachments/assets/73bd71a8-bf8c-4270-bcc0-54e439c0dac6" />


<img width="1801" height="469" alt="image" src="https://github.com/user-attachments/assets/527f754f-c2a7-4e3c-99a6-44b9787b81d1" />


<img width="1420" height="355" alt="image" src="https://github.com/user-attachments/assets/439ef20e-e460-46a8-b695-92e05079fc54" />

Create notification successfully
<img width="1440" height="695" alt="image" src="https://github.com/user-attachments/assets/5d06213a-091f-4d4a-899f-e35a688957a5" />


After update feedback from pending to toxic and reverse
<img width="1919" height="174" alt="image" src="https://github.com/user-attachments/assets/e0821eff-a0b5-4a67-b981-0b079aabc59a" />
Create notification feedback 
<img width="1916" height="266" alt="image" src="https://github.com/user-attachments/assets/facb05a0-fc64-42e7-9aeb-d894f8dedaa8" />




## ⚠️ Breaking changes?

- [ ] Yes
- [ ] No
