### PR TITLE
Fix/bug 17/handle loading error state when student accesses a feedback details

### DIFF
--- a/frontend/src/app/(layout)/forum/announcements/[id]/page.tsx
+++ b/frontend/src/app/(layout)/forum/announcements/[id]/page.tsx
@@ -52,7 +52,7 @@ const Page = () => {
       <div className="flex h-full w-full grow flex-col items-center justify-center">
         <EmptyState
           title="Lỗi tải dữ liệu"
-          description="Đã có lỗi xảy ra trong quá trình tải thông tin thông báo. Vui lòng thử lại."
+          description="Dữ liệu không tồn tại hoặc đường dẫn không hợp lệ."
           retryAction={() => refetch()}
           errorCode="FETCH_ERROR"
         />

--- a/frontend/src/app/(layout)/forum/posts/[id]/page.tsx
+++ b/frontend/src/app/(layout)/forum/posts/[id]/page.tsx
@@ -55,7 +55,7 @@ const Page = () => {
       <div className="flex h-full w-full grow flex-col items-center justify-center">
         <EmptyState
           title="Lỗi tải dữ liệu"
-          description="Đã có lỗi xảy ra trong quá trình tải thông tin bài viết. Vui lòng thử lại."
+          description="Dữ liệu không tồn tại hoặc đường dẫn không hợp lệ."
           retryAction={() => refetch()}
           errorCode="FETCH_ERROR"
         />

--- a/frontend/src/app/(layout)/staff/announcement-management/edit/[id]/page.tsx
+++ b/frontend/src/app/(layout)/staff/announcement-management/edit/[id]/page.tsx
@@ -60,7 +60,7 @@ const Page = () => {
       <div className="flex h-full w-full grow flex-col items-center justify-center">
         <EmptyState
           title="Lỗi tải dữ liệu"
-          description="Đã có lỗi xảy ra trong quá trình tải thông tin thông báo. Vui lòng thử lại."
+          description="Dữ liệu không tồn tại hoặc đường dẫn không hợp lệ."
           retryAction={() => refetch()}
           errorCode="FETCH_ERROR"
         />

--- a/frontend/src/app/(layout)/staff/list-feedbacks/[id]/page.tsx
+++ b/frontend/src/app/(layout)/staff/list-feedbacks/[id]/page.tsx
@@ -47,7 +47,7 @@ const Page = () => {
       <div className="flex h-full w-full grow flex-col items-center justify-center">
         <EmptyState
           title="Lỗi tải dữ liệu"
-          description="Đã có lỗi xảy ra trong quá trình tải thông tin phản hồi. Vui lòng thử lại."
+          description="Dữ liệu không tồn tại hoặc đường dẫn không hợp lệ."
           retryAction={() => refetch()}
           errorCode="FETCH_ERROR"
         />

--- a/frontend/src/app/(layout)/student/my-feedbacks/[id]/page.tsx
+++ b/frontend/src/app/(layout)/student/my-feedbacks/[id]/page.tsx
@@ -49,7 +49,7 @@ const Page = () => {
       <div className="flex h-full w-full grow flex-col items-center justify-center">
         <EmptyState
           title="Lỗi tải dữ liệu"
-          description="Đã có lỗi xảy ra trong quá trình tải thông tin phản hồi. Vui lòng thử lại."
+          description="Dữ liệu không tồn tại hoặc đường dẫn không hợp lệ."
           retryAction={() => refetch()}
           errorCode="FETCH_ERROR"
         />


### PR DESCRIPTION
## 🔗 Related Issue

Closes #139 

## 🆕 What’s changed?

- handle loading/error state when a student access a feedback details

## 🎯 Purpose

- enhance UI/UX

## 📸 Screenshot at your local?

<img width="1919" height="1035" alt="image" src="https://github.com/user-attachments/assets/0fcbbfc4-fa9a-46df-a1c5-30ef3aa18fe4" />


## ⚠️ Breaking changes?

- [ ] Yes
- [X] No
