### PR TITLE
Feat/handle UI for new feedback status

### DIFF
--- a/frontend/src/components/common/StatusBadge.tsx
+++ b/frontend/src/components/common/StatusBadge.tsx
@@ -4,6 +4,7 @@ import {
   CircleX,
   Forward,
   Loader,
+  TriangleAlert,
 } from "lucide-react";
 import { Badge } from "../ui/badge";
 import { cn } from "@/lib/utils";
@@ -78,7 +79,7 @@ const STATUS_CONFIG = {
   },
   VIOLATED_CONTENT: {
     text: "Vi phạm",
-    icon: CircleAlert,
+    icon: TriangleAlert,
     badgeClassName: "text-red-500 bg-red-100 hover:bg-red-200/35",
     iconClassName: "text-red-500 animate-pulse",
     textClassName: "",

--- a/frontend/src/components/common/StatusBadge.tsx
+++ b/frontend/src/components/common/StatusBadge.tsx
@@ -16,6 +16,7 @@ export type StatusBadgeProps = {
     | "REJECTED"
     | "CLOSED"
     | "FORWARDED"
+    | "VIOLATED_CONTENT"
     | "OPENING";
 };
 
@@ -73,6 +74,13 @@ const STATUS_CONFIG = {
     icon: Forward,
     badgeClassName: "text-purple-800 bg-purple-200/60 hover:bg-purple-200 ",
     iconClassName: "text-purple-800 animate-pulse",
+    textClassName: "",
+  },
+  VIOLATED_CONTENT: {
+    text: "Vi phạm",
+    icon: CircleAlert,
+    badgeClassName: "text-red-500 bg-red-100 hover:bg-red-200/35",
+    iconClassName: "text-red-500 animate-pulse",
     textClassName: "",
   },
 };

--- a/frontend/src/components/common/WarningBox.tsx
+++ b/frontend/src/components/common/WarningBox.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { AlertTriangle, XCircle, Info, CheckCircle2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface WarningBoxProps {
+  title?: string;
+  message: string;
+  variant?: "warning" | "error" | "info" | "success";
+  className?: string;
+}
+
+const variantStyles = {
+  warning: {
+    container: "bg-amber-50 border-amber-200 shadow-amber-100/50",
+    icon: <AlertTriangle className="h-5 w-5 text-amber-600" />,
+    title: "text-amber-900",
+    message: "text-amber-800",
+  },
+  error: {
+    container: "bg-red-50 border-red-200 shadow-red-100/50",
+    icon: <XCircle className="h-5 w-5 text-red-600" />,
+    title: "text-red-900",
+    message: "text-red-800",
+  },
+  info: {
+    container: "bg-blue-50 border-blue-200 shadow-blue-100/50",
+    icon: <Info className="h-5 w-5 text-blue-600" />,
+    title: "text-blue-900",
+    message: "text-blue-800",
+  },
+  success: {
+    container: "bg-emerald-50 border-emerald-200 shadow-emerald-100/50",
+    icon: <CheckCircle2 className="h-5 w-5 text-emerald-600" />,
+    title: "text-emerald-900",
+    message: "text-emerald-800",
+  },
+};
+
+const WarningBox = ({
+  title,
+  message,
+  variant = "warning",
+  className,
+}: WarningBoxProps) => {
+  const styles = variantStyles[variant];
+
+  return (
+    <div
+      className={cn(
+        "flex w-full items-start gap-3 rounded-xl border p-4 shadow-sm transition-all duration-200",
+        styles.container,
+        className,
+      )}
+    >
+      <div className="mt-0.5 shrink-0">{styles.icon}</div>
+      <div className="flex flex-col gap-1">
+        {title && (
+          <h4 className={cn("text-sm leading-tight font-bold", styles.title)}>
+            {title}
+          </h4>
+        )}
+        <p className={cn("text-[13px] leading-relaxed", styles.message)}>
+          {message}
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default WarningBox;

--- a/frontend/src/components/feedback/FeedbackDetailHeader.tsx
+++ b/frontend/src/components/feedback/FeedbackDetailHeader.tsx
@@ -12,6 +12,7 @@ import {
 import Link from "next/link";
 import ConfirmationDialog from "../common/ConfirmationDialog";
 import StatusBadge, { StatusBadgeProps } from "../common/StatusBadge";
+import WarningBox from "../common/WarningBox";
 import { Badge } from "../ui/badge"; // Import Badge
 import { Button } from "../ui/button";
 import Attachment from "./Attachment";
@@ -143,9 +144,19 @@ const FeedbackDetailHeader = ({ type = "student", data }: Props) => {
             </Badge>
           )}
         </div>
+
+        {/* Warning for Violated Content */}
+        {type === "student" && currentStatus === "VIOLATED_CONTENT" && (
+          <WarningBox
+            variant="warning"
+            title="Cảnh báo: Nội dung vi phạm quy định"
+            message="Nội dung phản hồi của bạn đã được xác định là vi phạm tiêu chuẩn cộng đồng hoặc quy định của nhà trường. Vui lòng chỉnh sửa nội dung để được tiếp tục xem xét và xử lý."
+          />
+        )}
+
         {/* Description */}
         <div>
-          <h2 className="text-[18px] font-medium">Nội dung:</h2>
+          <h2 className="text-[18px] font-medium">Nội dung:</h2>{" "}
           <div
             className="text-[13px] font-normal text-black lg:text-[14px]"
             dangerouslySetInnerHTML={{

--- a/frontend/src/components/feedback/FeedbackDetailHeader.tsx
+++ b/frontend/src/components/feedback/FeedbackDetailHeader.tsx
@@ -55,31 +55,32 @@ const FeedbackDetailHeader = ({ type = "student", data }: Props) => {
            consequuntur molestias, veniam illum dolores.
            `}
           </h1>
-          {type === "student" && currentStatus === "PENDING" && (
-            <div className="order-1 flex flex-row items-center gap-2 md:order-2">
-              <Link href={`/student/my-feedbacks/${id}/edit`}>
-                <Button className="h-fit border bg-gray-100/70 p-2 text-xs font-normal text-black shadow-xs hover:bg-gray-100">
-                  <SquarePen className="h-4 w-4 text-black" />
-                  Sửa
-                </Button>
-              </Link>
-              <ConfirmationDialog
-                title="Xác nhận xóa"
-                description="Bạn có chắc chắn muốn xóa phản hồi này không? Hành động này không thể hoàn tác."
-                onConfirm={handleDelete}
-                confirmText="Xóa"
-                cancelText="Hủy"
-              >
-                <Button
-                  className="h-fit border bg-red-500 p-2 text-xs font-normal text-white shadow-xs hover:bg-red-400"
-                  disabled={isPending}
+          {(type === "student" && currentStatus === "PENDING") ||
+            (currentStatus === "VIOLATED_CONTENT" && (
+              <div className="order-1 flex flex-row items-center gap-2 md:order-2">
+                <Link href={`/student/my-feedbacks/${id}/edit`}>
+                  <Button className="h-fit border bg-gray-100/70 p-2 text-xs font-normal text-black shadow-xs hover:bg-gray-100">
+                    <SquarePen className="h-4 w-4 text-black" />
+                    Sửa
+                  </Button>
+                </Link>
+                <ConfirmationDialog
+                  title="Xác nhận xóa"
+                  description="Bạn có chắc chắn muốn xóa phản hồi này không? Hành động này không thể hoàn tác."
+                  onConfirm={handleDelete}
+                  confirmText="Xóa"
+                  cancelText="Hủy"
                 >
-                  <Trash2 className="h-4 w-4 text-white" />
-                  Xóa
-                </Button>
-              </ConfirmationDialog>
-            </div>
-          )}
+                  <Button
+                    className="h-fit border bg-red-500 p-2 text-xs font-normal text-white shadow-xs hover:bg-red-400"
+                    disabled={isPending}
+                  >
+                    <Trash2 className="h-4 w-4 text-white" />
+                    Xóa
+                  </Button>
+                </ConfirmationDialog>
+              </div>
+            ))}
         </div>
 
         {/* Information */}

--- a/frontend/src/components/feedback/FeedbackDetailHeader.tsx
+++ b/frontend/src/components/feedback/FeedbackDetailHeader.tsx
@@ -56,8 +56,9 @@ const FeedbackDetailHeader = ({ type = "student", data }: Props) => {
            consequuntur molestias, veniam illum dolores.
            `}
           </h1>
-          {(type === "student" && currentStatus === "PENDING") ||
-            (currentStatus === "VIOLATED_CONTENT" && (
+          {type === "student" &&
+            (currentStatus === "PENDING" ||
+              currentStatus === "VIOLATED_CONTENT") && (
               <div className="order-1 flex flex-row items-center gap-2 md:order-2">
                 <Link href={`/student/my-feedbacks/${id}/edit`}>
                   <Button className="h-fit border bg-gray-100/70 p-2 text-xs font-normal text-black shadow-xs hover:bg-gray-100">
@@ -81,7 +82,7 @@ const FeedbackDetailHeader = ({ type = "student", data }: Props) => {
                   </Button>
                 </ConfirmationDialog>
               </div>
-            ))}
+            )}
         </div>
 
         {/* Information */}

--- a/frontend/src/constants/data.ts
+++ b/frontend/src/constants/data.ts
@@ -4,4 +4,5 @@ export const FeedbackStatus = [
   { label: "Đang xử lý", value: "in_progress" },
   { label: "Đã xử lý", value: "resolved" },
   { label: "Từ chối", value: "rejected" },
+  { label: "Vi phạm", value: "violated_content" },
 ];

--- a/frontend/src/types/feedback.ts
+++ b/frontend/src/types/feedback.ts
@@ -4,6 +4,7 @@ export type FeedbackStatus =
   | "PENDING"
   | "IN_PROGRESS"
   | "RESOLVED"
+  | "VIOLATED_CONTENT"
   | "REJECTED";
 export type FeedbackDetail = {
   id: string;


### PR DESCRIPTION
## 🔗 Related Issue

Closes #160 

## 🆕 What’s changed?

- Add a new badge for status VIOLATED_CONTENT
- Add a Warning box below the the header of feedback with status VIOLATED_CONTENT

## 🎯 Purpose

- enhance UI

## 📸 Screenshot at your local?

- 
<img width="1919" height="947" alt="image" src="https://github.com/user-attachments/assets/4514b3cc-aa02-42c1-b147-eb89beaca817" />


## ⚠️ Breaking changes?

- [ ] Yes
- [x] No
