### PR TITLE
fix: filter feedbacks have content toxic on forum

### DIFF
--- a/backend/src/modules/forum/dto/hidden-status.dto.ts
+++ b/backend/src/modules/forum/dto/hidden-status.dto.ts
@@ -1,0 +1,9 @@
+import { FeedbackStatus } from '@prisma/client';
+
+export const HIDDEN_FORUM_FEEDBACK_STATUSES: FeedbackStatus[] = [
+  FeedbackStatus.VIOLATED_CONTENT,
+  FeedbackStatus.AI_REVIEW_FAILED,
+];
+export function isHiddenForumFeedbackStatus(status: FeedbackStatus): boolean {
+  return HIDDEN_FORUM_FEEDBACK_STATUSES.includes(status);
+}

--- a/backend/src/modules/forum/forum.service.ts
+++ b/backend/src/modules/forum/forum.service.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Injectable } from '@nestjs/common';
 
-import { FileTargetType, Prisma } from '@prisma/client';
+import { FeedbackStatus, FileTargetType, Prisma } from '@prisma/client';
 import { PrismaService } from 'src/modules/prisma/prisma.service';
 import {
   GetPostsResponseDto,
@@ -44,6 +44,12 @@ export class ForumService {
         ...(categoryId && { categoryId }),
         ...(departmentId && { departmentId }),
         ...(q && { subject: { contains: q, mode: 'insensitive' } }),
+        currentStatus: {
+          notIn: [
+            FeedbackStatus.VIOLATED_CONTENT,
+            FeedbackStatus.AI_REVIEW_FAILED,
+          ],
+        },
       },
       ...(from || to
         ? {
@@ -190,7 +196,12 @@ export class ForumService {
         },
       },
     });
-
+    if (
+      post?.feedback.currentStatus === FeedbackStatus.VIOLATED_CONTENT ||
+      post?.feedback.currentStatus === FeedbackStatus.AI_REVIEW_FAILED
+    ) {
+      throw new NotFoundException(`Post not found`);
+    }
     if (!post) {
       throw new NotFoundException(`Post not found`);
     }

--- a/backend/src/modules/forum/forum.service.ts
+++ b/backend/src/modules/forum/forum.service.ts
@@ -196,13 +196,15 @@ export class ForumService {
         },
       },
     });
+
+    if (!post) {
+      throw new NotFoundException(`Post not found`);
+    }
+
     if (
       post?.feedback.currentStatus === FeedbackStatus.VIOLATED_CONTENT ||
       post?.feedback.currentStatus === FeedbackStatus.AI_REVIEW_FAILED
     ) {
-      throw new NotFoundException(`Post not found`);
-    }
-    if (!post) {
       throw new NotFoundException(`Post not found`);
     }
     const resolvedStatus = post.feedback.statusHistory.find(

--- a/backend/src/modules/forum/forum.service.ts
+++ b/backend/src/modules/forum/forum.service.ts
@@ -1,7 +1,7 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Injectable } from '@nestjs/common';
 
-import { FeedbackStatus, FileTargetType, Prisma } from '@prisma/client';
+import { FileTargetType, Prisma } from '@prisma/client';
 import { PrismaService } from 'src/modules/prisma/prisma.service';
 import {
   GetPostsResponseDto,
@@ -14,6 +14,10 @@ import { UploadsService } from '../uploads/uploads.service';
 import { ActiveUserData } from '../auth/interfaces/active-user-data.interface';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { ForumPostVotedEvent } from './events/forum-post-voted.event';
+import {
+  HIDDEN_FORUM_FEEDBACK_STATUSES,
+  isHiddenForumFeedbackStatus,
+} from './dto/hidden-status.dto';
 @Injectable()
 export class ForumService {
   constructor(
@@ -45,10 +49,7 @@ export class ForumService {
         ...(departmentId && { departmentId }),
         ...(q && { subject: { contains: q, mode: 'insensitive' } }),
         currentStatus: {
-          notIn: [
-            FeedbackStatus.VIOLATED_CONTENT,
-            FeedbackStatus.AI_REVIEW_FAILED,
-          ],
+          notIn: HIDDEN_FORUM_FEEDBACK_STATUSES,
         },
       },
       ...(from || to
@@ -201,10 +202,7 @@ export class ForumService {
       throw new NotFoundException(`Post not found`);
     }
 
-    if (
-      post?.feedback.currentStatus === FeedbackStatus.VIOLATED_CONTENT ||
-      post?.feedback.currentStatus === FeedbackStatus.AI_REVIEW_FAILED
-    ) {
+    if (isHiddenForumFeedbackStatus(post?.feedback.currentStatus)) {
       throw new NotFoundException(`Post not found`);
     }
     const resolvedStatus = post.feedback.statusHistory.find(


### PR DESCRIPTION
## 🔗 Related Issue

Closes #

## 🆕 What’s changed?

- Thay đổi code trong file forum service để lọc feedback diên đàn

## 🎯 Purpose

- Lọc những feedback có trạng thái bị toxic hoặc bị ai reviewed failed trên diễn đàn

## 📸 Screenshot at your local?

- TBC
Trước khi lọc
<img width="1919" height="955" alt="Screenshot 2026-03-31 104738" src="https://github.com/user-attachments/assets/6219fed8-20db-48ed-b5ed-c8864c3f7d9d" />

Sau khi lọc
<img width="1919" height="953" alt="Screenshot 2026-03-31 104757" src="https://github.com/user-attachments/assets/5bae9393-9512-4fd6-8282-7d8c9ff90494" />


## ⚠️ Breaking changes?

- [ ] Yes
- [ ] No
