### PR TITLE
fix: update status feedback history for staff filter

### DIFF
--- a/backend/src/modules/feedback_management/feedback_management.service.ts
+++ b/backend/src/modules/feedback_management/feedback_management.service.ts
@@ -177,7 +177,8 @@ export class FeedbackManagementService {
             note: true,
             createdAt: true,
           },
-          orderBy: { createdAt: 'asc' },
+          orderBy: { createdAt: 'desc' },
+          take: 2,
         },
         forwardingLogs: {
           select: {
@@ -213,6 +214,15 @@ export class FeedbackManagementService {
       feedback.forwardingLogs.some(
         (log) => log.fromDepartment.id === actor.departmentId,
       );
+    const latestStatus = feedback.statusHistory[1].status;
+    if (
+      latestStatus === FeedbackStatus.VIOLATED_CONTENT ||
+      latestStatus === FeedbackStatus.AI_REVIEW_FAILED
+    ) {
+      feedback.statusHistory = feedback.statusHistory.filter(
+        (sh) => sh.status === latestStatus,
+      );
+    }
     const unifiedTimeline = mergeStatusAndForwardLogs({
       statusHistory: feedback.statusHistory,
       forwardingLogs: feedback.forwardingLogs.map((f) => ({

--- a/backend/src/modules/feedback_management/feedback_management.service.ts
+++ b/backend/src/modules/feedback_management/feedback_management.service.ts
@@ -171,14 +171,18 @@ export class FeedbackManagementService {
           select: { id: true, name: true },
         },
         statusHistory: {
+          where: {
+            status: {
+              in: ['PENDING', 'IN_PROGRESS', 'RESOLVED', 'REJECTED'],
+            },
+          },
           select: {
             status: true,
             message: true,
             note: true,
             createdAt: true,
           },
-          orderBy: { createdAt: 'desc' },
-          take: 2,
+          orderBy: { createdAt: 'asc' },
         },
         forwardingLogs: {
           select: {
@@ -209,6 +213,18 @@ export class FeedbackManagementService {
     if (!feedback) {
       throw new NotFoundException('Feedback not found');
     }
+
+    const latestPending = feedback.statusHistory
+      .filter((x) => x.status === 'PENDING')
+      .at(-1);
+    const otherStatuses = feedback.statusHistory.filter(
+      (x) => x.status !== 'PENDING',
+    );
+    feedback.statusHistory = [
+      ...(latestPending ? [latestPending] : []),
+      ...otherStatuses,
+    ];
+
     const isForwarding =
       feedback.department.id !== actor.departmentId &&
       feedback.forwardingLogs.some(

--- a/backend/src/modules/feedback_management/feedback_management.service.ts
+++ b/backend/src/modules/feedback_management/feedback_management.service.ts
@@ -214,15 +214,6 @@ export class FeedbackManagementService {
       feedback.forwardingLogs.some(
         (log) => log.fromDepartment.id === actor.departmentId,
       );
-    const latestStatus = feedback.statusHistory[1].status;
-    if (
-      latestStatus === FeedbackStatus.VIOLATED_CONTENT ||
-      latestStatus === FeedbackStatus.AI_REVIEW_FAILED
-    ) {
-      feedback.statusHistory = feedback.statusHistory.filter(
-        (sh) => sh.status === latestStatus,
-      );
-    }
     const unifiedTimeline = mergeStatusAndForwardLogs({
       statusHistory: feedback.statusHistory,
       forwardingLogs: feedback.forwardingLogs.map((f) => ({


### PR DESCRIPTION
## 🔗 Related Issue

Closes #

## 🆕 What’s changed?

- Changes in the feedback management service file.

## 🎯 Purpose

- Filter feedback history for staff to see if anyone's review failed or violated content.

## 📸 Screenshot at your local?

Initial Image case 1

<img width="1919" height="957" alt="Screenshot 2026-05-01 122458" src="https://github.com/user-attachments/assets/0b6178a4-96b9-4498-9ddb-25fc9e4f2024" />


After update content case1
<img width="1919" height="948" alt="Screenshot 2026-05-01 122539" src="https://github.com/user-attachments/assets/affece16-638e-4661-9d37-4f3ddf26b3ee" />

Initial Image case2
<img width="1919" height="949" alt="Screenshot 2026-05-01 122902" src="https://github.com/user-attachments/assets/f9762aeb-a639-49a2-a259-f47ed3c7b746" />



After update content case2

<img width="1914" height="945" alt="Screenshot 2026-05-01 122837" src="https://github.com/user-attachments/assets/5ded38f8-7146-4f2d-8647-23d264e07d0c" />










## ⚠️ Breaking changes?

- [ ] Yes
- [ ] No
