### PR TITLE
Feat/upload user avatar

### DIFF
--- a/backend/prisma/migrations/20260519161727_add_user_avatar/migration.sql
+++ b/backend/prisma/migrations/20260519161727_add_user_avatar/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "FileTargetType" ADD VALUE 'AVATAR';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -93,6 +93,7 @@ enum FileTargetType {
   FEEDBACK
   MESSAGE
   ANNOUNCEMENT
+  AVATAR
 }
 
 

--- a/backend/src/modules/uploads/dto/create-avatar-attachment.dto.ts
+++ b/backend/src/modules/uploads/dto/create-avatar-attachment.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsIn, IsNotEmpty, IsString } from 'class-validator';
+import { ALLOWED_AVATAR_FILE_TYPES } from './file-attachment.dto';
+import { CreateFileAttachmentDto } from './create-file-attachment.dto';
+
+export class CreateAvatarAttachmentDto extends CreateFileAttachmentDto {
+  @ApiProperty({ example: 'image/png', enum: ALLOWED_AVATAR_FILE_TYPES })
+  @IsString()
+  @IsNotEmpty()
+  @IsIn(ALLOWED_AVATAR_FILE_TYPES, {
+    message: 'Avatar file type must be PNG or JPEG',
+  })
+  declare fileType: string;
+}

--- a/backend/src/modules/uploads/dto/file-attachment.dto.ts
+++ b/backend/src/modules/uploads/dto/file-attachment.dto.ts
@@ -11,12 +11,14 @@ import {
   Matches,
   NotContains,
 } from 'class-validator';
-// GENERAL CONSTANTS
+// GENERAL CONSTANTS (feedbacks, announcements, clarifications, etc.)
 export const ALLOWED_FILE_TYPES = [
   'image/png',
   'image/jpeg',
   'application/pdf',
 ];
+
+export const ALLOWED_AVATAR_FILE_TYPES = ['image/png', 'image/jpeg'];
 export const MAX_FILE_SIZE = 100 * 1024 * 1024; // 100MB
 
 export class BaseFileItemDto {

--- a/backend/src/modules/uploads/dto/index.ts
+++ b/backend/src/modules/uploads/dto/index.ts
@@ -1,3 +1,4 @@
 export * from './file-attachment.dto';
 export * from './create-file-attachment.dto';
+export * from './create-avatar-attachment.dto';
 export * from './uploads.dto';

--- a/backend/src/modules/uploads/uploads.service.ts
+++ b/backend/src/modules/uploads/uploads.service.ts
@@ -6,6 +6,7 @@ import {
 import { PrismaService } from '../prisma/prisma.service';
 import { FileTargetType } from '@prisma/client';
 import {
+  ALLOWED_AVATAR_FILE_TYPES,
   ALLOWED_FILE_TYPES,
   FileAttachmentDto,
   MAX_FILE_SIZE,
@@ -53,7 +54,12 @@ export class UploadsService {
 
     // ===== 1. Validate  backend  =====
 
-    if (!ALLOWED_FILE_TYPES.includes(fileType)) {
+    const allowedTypes =
+      targetType === FileTargetType.AVATAR
+        ? ALLOWED_AVATAR_FILE_TYPES
+        : ALLOWED_FILE_TYPES;
+
+    if (!allowedTypes.includes(fileType)) {
       throw new BadRequestException('File type not allowed');
     }
 
@@ -161,6 +167,15 @@ export class UploadsService {
     targetType: FileTargetType,
     newFiles: CreateFileAttachmentDto[],
   ): Promise<FileAttachmentDto[]> {
+    if (targetType === FileTargetType.AVATAR && newFiles?.length) {
+      const invalid = newFiles.filter(
+        (f) => !ALLOWED_AVATAR_FILE_TYPES.includes(f.fileType),
+      );
+      if (invalid.length > 0) {
+        throw new BadRequestException('Avatar file type must be PNG or JPEG');
+      }
+    }
+
     const existingFiles = await this.getAttachmentsForTarget(
       targetId,
       targetType,

--- a/backend/src/modules/users/dto/update-profile.dto.ts
+++ b/backend/src/modules/users/dto/update-profile.dto.ts
@@ -1,6 +1,6 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsOptional, IsString, MinLength } from 'class-validator';
-import { CreateFileAttachmentDto } from 'src/modules/uploads/dto';
+import { CreateAvatarAttachmentDto } from 'src/modules/uploads/dto';
 
 export class UpdateProfileDto {
   @ApiPropertyOptional({
@@ -13,8 +13,8 @@ export class UpdateProfileDto {
   fullName?: string;
   @ApiPropertyOptional({
     description: 'The new avatar of the user',
-    type: CreateFileAttachmentDto,
+    type: CreateAvatarAttachmentDto,
   })
   @IsOptional()
-  attachment?: CreateFileAttachmentDto;
+  attachment?: CreateAvatarAttachmentDto;
 }

--- a/backend/src/modules/users/dto/update-profile.dto.ts
+++ b/backend/src/modules/users/dto/update-profile.dto.ts
@@ -1,5 +1,6 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsOptional, IsString, MinLength } from 'class-validator';
+import { CreateFileAttachmentDto } from 'src/modules/uploads/dto';
 
 export class UpdateProfileDto {
   @ApiPropertyOptional({
@@ -10,4 +11,10 @@ export class UpdateProfileDto {
   @IsString()
   @MinLength(1)
   fullName?: string;
+  @ApiPropertyOptional({
+    description: 'The new avatar of the user',
+    type: CreateFileAttachmentDto,
+  })
+  @IsOptional()
+  attachment?: CreateFileAttachmentDto;
 }

--- a/backend/src/modules/users/dto/user-response.dto.ts
+++ b/backend/src/modules/users/dto/user-response.dto.ts
@@ -55,5 +55,5 @@ export class UserResponseDto {
     type: [FileAttachmentDto],
     description: 'Avatar of the user',
   })
-  attachment: FileAttachmentDto;
+  attachment: FileAttachmentDto | null;
 }

--- a/backend/src/modules/users/dto/user-response.dto.ts
+++ b/backend/src/modules/users/dto/user-response.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { UserRole } from '@prisma/client';
+import { FileAttachmentDto } from 'src/modules/uploads/dto';
 
 export class UserResponseDto {
   @ApiProperty({
@@ -49,4 +50,10 @@ export class UserResponseDto {
     description: 'Date when the user was created',
   })
   createdAt: string;
+
+  @ApiProperty({
+    type: [FileAttachmentDto],
+    description: 'Avatar of the user',
+  })
+  attachment: FileAttachmentDto;
 }

--- a/backend/src/modules/users/users.controller.ts
+++ b/backend/src/modules/users/users.controller.ts
@@ -1,11 +1,12 @@
 // users.controller.ts
-import { Body, Controller, Get, Patch } from '@nestjs/common';
+import { Body, Controller, Get, Patch, Post } from '@nestjs/common';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { UserResponseDto } from './dto/user-response.dto';
 import { UsersService } from './users.service';
 import { ActiveUser } from '../auth/decorators/active-user.decorator';
 import type { ActiveUserData } from '../auth/interfaces/active-user-data.interface';
 import { UpdateProfileDto } from './dto/update-profile.dto';
+import { CreateFileAttachmentDto } from '../uploads/dto';
 
 @ApiTags('Users')
 @Controller('users')
@@ -19,6 +20,15 @@ export class UsersController {
     return this.usersService.getUser(actor);
   }
 
+  @ApiOperation({ summary: 'Upload user avatar' })
+  @ApiOkResponse({ type: UserResponseDto })
+  @Post('upload/avatar')
+  async uploadAvatar(
+    @ActiveUser() actor: ActiveUserData,
+    @Body() fileAttachment: CreateFileAttachmentDto,
+  ): Promise<UserResponseDto> {
+    return this.usersService.uploadAvatar(actor, fileAttachment);
+  }
   @ApiOperation({ summary: 'Update user profile' })
   @ApiOkResponse({ type: UserResponseDto })
   @Patch('update/me')

--- a/backend/src/modules/users/users.controller.ts
+++ b/backend/src/modules/users/users.controller.ts
@@ -6,7 +6,7 @@ import { UsersService } from './users.service';
 import { ActiveUser } from '../auth/decorators/active-user.decorator';
 import type { ActiveUserData } from '../auth/interfaces/active-user-data.interface';
 import { UpdateProfileDto } from './dto/update-profile.dto';
-import { CreateFileAttachmentDto } from '../uploads/dto';
+import { CreateAvatarAttachmentDto } from '../uploads/dto';
 
 @ApiTags('Users')
 @Controller('users')
@@ -25,7 +25,7 @@ export class UsersController {
   @Post('upload/avatar')
   async uploadAvatar(
     @ActiveUser() actor: ActiveUserData,
-    @Body() fileAttachment: CreateFileAttachmentDto,
+    @Body() fileAttachment: CreateAvatarAttachmentDto,
   ): Promise<UserResponseDto> {
     return this.usersService.uploadAvatar(actor, fileAttachment);
   }

--- a/backend/src/modules/users/users.module.ts
+++ b/backend/src/modules/users/users.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
+import { UploadsModule } from '../uploads/uploads.module';
 
 @Module({
   controllers: [UsersController],
   providers: [UsersService],
+  imports: [UploadsModule],
 })
 export class UsersModule {}

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -6,15 +6,21 @@ import { ActiveUserData } from '../auth/interfaces/active-user-data.interface';
 import { UsersServiceContract } from './users.service.contract';
 import { UpdateProfileDto } from './dto/update-profile.dto';
 
-import { Users, Departments } from '@prisma/client';
+import { Users, Departments, FileTargetType } from '@prisma/client';
+import { CreateFileAttachmentDto, FileAttachmentDto } from '../uploads/dto';
+import { UploadsService } from '../uploads/uploads.service';
 
 type UserWithDepartment = Users & {
   department?: Pick<Departments, 'id' | 'name' | 'email' | 'location'> | null;
+  attachment: FileAttachmentDto;
 };
 
 @Injectable()
 export class UsersService implements UsersServiceContract {
-  constructor(private prisma: PrismaService) {}
+  constructor(
+    private prisma: PrismaService,
+    private uploadsService: UploadsService,
+  ) {}
 
   private mapToUserResponse(user: UserWithDepartment): UserResponseDto {
     return {
@@ -23,6 +29,7 @@ export class UsersService implements UsersServiceContract {
       email: user.email,
       role: user.role,
       createdAt: user.createdAt.toISOString(),
+      attachment: user.attachment,
       ...(user.department
         ? {
             department: {
@@ -50,12 +57,18 @@ export class UsersService implements UsersServiceContract {
         },
       },
     });
-
     if (!user) {
       throw new NotFoundException(`User with ID ${actor.sub} not found`);
     }
+    const attachment = await this.uploadsService.getAttachmentsForTarget(
+      user.id,
+      FileTargetType.AVATAR,
+    );
+    if (!attachment) {
+      throw new NotFoundException(`Avatar not found for user ${actor.sub}`);
+    }
 
-    return this.mapToUserResponse(user);
+    return this.mapToUserResponse({ ...user, attachment: attachment[0] });
   }
 
   async updateMe(
@@ -86,7 +99,37 @@ export class UsersService implements UsersServiceContract {
         },
       },
     });
-
-    return this.mapToUserResponse(updatedUser);
+    let attachment: FileAttachmentDto[] = [];
+    if (dto.attachment) {
+      attachment = await this.uploadsService.updateAttachmentsForTarget(
+        user.id,
+        FileTargetType.AVATAR,
+        [dto.attachment],
+      );
+    }
+    return this.mapToUserResponse({
+      ...updatedUser,
+      attachment: attachment[0],
+    });
+  }
+  async uploadAvatar(
+    actor: ActiveUserData,
+    fileAttachment: CreateFileAttachmentDto,
+  ): Promise<UserResponseDto> {
+    const user = await this.prisma.users.findUnique({
+      where: { id: actor.sub },
+    });
+    if (!user) {
+      throw new NotFoundException(`User with ID ${actor.sub} not found`);
+    }
+    let files: FileAttachmentDto[] = [];
+    if (fileAttachment) {
+      files = await this.uploadsService.updateAttachmentsForTarget(
+        user.id,
+        FileTargetType.AVATAR,
+        [fileAttachment],
+      );
+    }
+    return this.mapToUserResponse({ ...user, attachment: files[0] });
   }
 }

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -12,7 +12,7 @@ import { UploadsService } from '../uploads/uploads.service';
 
 type UserWithDepartment = Users & {
   department?: Pick<Departments, 'id' | 'name' | 'email' | 'location'> | null;
-  attachment: FileAttachmentDto;
+  attachment: FileAttachmentDto | null;
 };
 
 @Injectable()
@@ -29,7 +29,7 @@ export class UsersService implements UsersServiceContract {
       email: user.email,
       role: user.role,
       createdAt: user.createdAt.toISOString(),
-      attachment: user.attachment,
+      attachment: user.attachment ?? null,
       ...(user.department
         ? {
             department: {
@@ -64,11 +64,11 @@ export class UsersService implements UsersServiceContract {
       user.id,
       FileTargetType.AVATAR,
     );
-    if (!attachment) {
-      throw new NotFoundException(`Avatar not found for user ${actor.sub}`);
-    }
 
-    return this.mapToUserResponse({ ...user, attachment: attachment[0] });
+    return this.mapToUserResponse({
+      ...user,
+      attachment: attachment?.[0] ?? null,
+    });
   }
 
   async updateMe(
@@ -109,7 +109,7 @@ export class UsersService implements UsersServiceContract {
     }
     return this.mapToUserResponse({
       ...updatedUser,
-      attachment: attachment[0],
+      attachment: attachment?.[0] ?? null,
     });
   }
   async uploadAvatar(
@@ -130,6 +130,6 @@ export class UsersService implements UsersServiceContract {
         [fileAttachment],
       );
     }
-    return this.mapToUserResponse({ ...user, attachment: files[0] });
+    return this.mapToUserResponse({ ...user, attachment: files?.[0] ?? null });
   }
 }

--- a/backend/src/modules/users/users.service.ts
+++ b/backend/src/modules/users/users.service.ts
@@ -7,7 +7,7 @@ import { UsersServiceContract } from './users.service.contract';
 import { UpdateProfileDto } from './dto/update-profile.dto';
 
 import { Users, Departments, FileTargetType } from '@prisma/client';
-import { CreateFileAttachmentDto, FileAttachmentDto } from '../uploads/dto';
+import { CreateAvatarAttachmentDto, FileAttachmentDto } from '../uploads/dto';
 import { UploadsService } from '../uploads/uploads.service';
 
 type UserWithDepartment = Users & {
@@ -114,7 +114,7 @@ export class UsersService implements UsersServiceContract {
   }
   async uploadAvatar(
     actor: ActiveUserData,
-    fileAttachment: CreateFileAttachmentDto,
+    fileAttachment: CreateAvatarAttachmentDto,
   ): Promise<UserResponseDto> {
     const user = await this.prisma.users.findUnique({
       where: { id: actor.sub },


### PR DESCRIPTION
## 🔗 Related Issue

Issuse: #188 

## 🆕 What’s changed?

- Added AVATAR support to FileTargetType in Prisma schema and database migration.
- Added avatar upload validation to only allow PNG and JPEG file types.
- Introduced ALLOWED_AVATAR_FILE_TYPES constant for centralized avatar validation.
- Added CreateAvatarAttachmentDto for avatar-specific attachment handling.
- Updated user profile DTOs and API responses to include avatar attachment data.
- Added avatar upload support to user update/upload endpoints.
- Updated UsersService to handle avatar upload, retrieval, and response mapping via UploadsService.

## 🎯 Purpose
- Enable users to upload and manage profile avatars securely.
- Restrict avatar uploads to supported image formats.
- Extend user profile APIs to expose avatar attachment information consistently.

## 📸 Screenshot at your local?

- TBC

## ⚠️ Breaking changes?

- [ ] Yes
- [x ] No
