### PR TITLE
Add bulk feedback forwarding functionality with DTOs and endpoint

### DIFF
--- a/backend/src/modules/feedback_management/dto/bulk-forward-feedback.dto.ts
+++ b/backend/src/modules/feedback_management/dto/bulk-forward-feedback.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ArrayMaxSize, ArrayMinSize, IsArray, IsUUID } from 'class-validator';
+import { CreateForwardingDto } from './create-forwarding.dto';
+
+export class BulkForwardFeedbackDto extends CreateForwardingDto {
+  @ApiProperty({
+    type: [String],
+    description:
+      'Feedback IDs to forward (same rules as single forward; out-of-scope IDs are skipped)',
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(100)
+  @IsUUID('loose', { each: true })
+  feedbackIds: string[];
+}

--- a/backend/src/modules/feedback_management/dto/feedback_management_response.dto.ts
+++ b/backend/src/modules/feedback_management/dto/feedback_management_response.dto.ts
@@ -164,3 +164,14 @@ export class BulkUpdateFeedbackStatusResponseDto {
   })
   skippedIds: string[];
 }
+
+export class BulkForwardFeedbackResponseDto {
+  @ApiProperty({ type: () => [ForwardingResponseDto] })
+  forwarded: ForwardingResponseDto[];
+
+  @ApiProperty({
+    type: [String],
+    description: 'IDs skipped (not found or not in scope for this staff)',
+  })
+  skippedIds: string[];
+}

--- a/backend/src/modules/feedback_management/dto/index.ts
+++ b/backend/src/modules/feedback_management/dto/index.ts
@@ -1,5 +1,6 @@
 export * from './feedback_management_response.dto';
 export * from './update-feedback-status.dto';
 export * from './bulk-update-feedback-status.dto';
+export * from './bulk-forward-feedback.dto';
 export * from './create-forwarding.dto';
 export * from './query-feedback_management.dto';

--- a/backend/src/modules/feedback_management/feedback_management.controller.ts
+++ b/backend/src/modules/feedback_management/feedback_management.controller.ts
@@ -16,6 +16,8 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import {
+  BulkForwardFeedbackDto,
+  BulkForwardFeedbackResponseDto,
   BulkUpdateFeedbackStatusDto,
   BulkUpdateFeedbackStatusResponseDto,
   FeedbackDetailDto,
@@ -81,6 +83,27 @@ export class FeedbackManagementController {
     @ActiveUser() actor: ActiveUserData,
   ): Promise<BulkUpdateFeedbackStatusResponseDto> {
     return this.feedbackManagementService.bulkUpdateFeedbackStatus(dto, actor);
+  }
+
+  @Post('/staff/feedbacks/bulk-forwardings')
+  @Roles(UserRole.DEPARTMENT_STAFF)
+  @ApiOperation({
+    summary: 'Bulk forward feedbacks to another department (Staff only)',
+    description:
+      'Forwards each ID with the same rules as single forward. IDs not in scope are skipped.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Per-item forwarding results and skipped IDs',
+    type: BulkForwardFeedbackResponseDto,
+  })
+  @ApiResponse({ status: 404, description: 'Target department not found' })
+  @ApiResponse({ status: 400, description: 'Invalid forwarding request' })
+  bulkForwardFeedback(
+    @Body() dto: BulkForwardFeedbackDto,
+    @ActiveUser() actor: ActiveUserData,
+  ): Promise<BulkForwardFeedbackResponseDto> {
+    return this.feedbackManagementService.bulkForwardFeedback(dto, actor);
   }
 
   @Get('/staff/feedbacks/:feedbackId')

--- a/backend/src/modules/feedback_management/feedback_management.service.ts
+++ b/backend/src/modules/feedback_management/feedback_management.service.ts
@@ -18,6 +18,8 @@ import { mergeStatusAndForwardLogs } from 'src/shared/helpers/merge-forwarding_l
 import { ActiveUserData } from '../auth/interfaces/active-user-data.interface';
 import { UploadsService } from '../uploads/uploads.service';
 import {
+  BulkForwardFeedbackDto,
+  BulkForwardFeedbackResponseDto,
   BulkUpdateFeedbackStatusDto,
   BulkUpdateFeedbackStatusItemDto,
   BulkUpdateFeedbackStatusResponseDto,
@@ -759,5 +761,32 @@ export class FeedbackManagementService {
     }
 
     return { updated, skippedIds };
+  }
+
+  async bulkForwardFeedback(
+    dto: BulkForwardFeedbackDto,
+    actor: ActiveUserData,
+  ): Promise<BulkForwardFeedbackResponseDto> {
+    const forwarded: ForwardingResponseDto[] = [];
+    const skippedIds: string[] = [];
+
+    for (const feedbackId of dto.feedbackIds) {
+      try {
+        const res = await this.createForwarding(
+          feedbackId,
+          { toDepartmentId: dto.toDepartmentId, note: dto.note },
+          actor,
+        );
+        forwarded.push(res);
+      } catch (e) {
+        if (e instanceof NotFoundException) {
+          skippedIds.push(feedbackId);
+          continue;
+        }
+        throw e;
+      }
+    }
+
+    return { forwarded, skippedIds };
   }
 }


### PR DESCRIPTION
…r endpoint

## 🔗 Related Issue

Issuse: #

## 🆕 What’s changed?
This pull request adds a new bulk forwarding feature to the feedback management module, allowing department staff to forward multiple feedback items to another department in a single request. It introduces new DTOs, controller endpoints, and service logic to support this operation, as well as updates to exports and imports for integration.

## 🎯 Purpose

-

## 📸 Screenshot at your local?

- TBC

## ⚠️ Breaking changes?

- [ ] Yes
- [ ] No
