### PR TITLE
fix: update posted_at field to use COALESCE for better date handling

### DIFF
--- a/data-pipeline/dbt_transformation/models/staging/stg_fb_posts.sql
+++ b/data-pipeline/dbt_transformation/models/staging/stg_fb_posts.sql
@@ -31,7 +31,10 @@ cleaned as (
         author,
         content,
         post_link,
-        SAFE_CAST(post_date AS TIMESTAMP) as posted_at,
+        COALESCE(
+            SAFE_CAST(post_date AS TIMESTAMP), 
+            SAFE_CAST(crawled_at AS TIMESTAMP)
+        ) as posted_at,
 
         SAFE_CAST(stats.reactions AS INT64) as reaction_count,
         SAFE_CAST(stats.comments AS INT64) as comment_count,

--- a/frontend/src/components/dashboard/social-listening/UrgentIssuesAlert.tsx
+++ b/frontend/src/components/dashboard/social-listening/UrgentIssuesAlert.tsx
@@ -1,9 +1,8 @@
-import React from "react";
-import { FeedbackPost } from "@/types/social-listening";
-import { AlertTriangle, ExternalLink, ShieldAlert } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { ScrollArea } from "@/components/ui/scroll-area";
+import { FeedbackPost } from "@/types/social-listening";
 import { format } from "date-fns";
+import { AlertTriangle, ExternalLink, ShieldAlert } from "lucide-react";
+import React from "react";
 
 interface UrgentIssuesAlertProps {
   issues: FeedbackPost[];
@@ -29,7 +28,7 @@ const UrgentIssuesAlert: React.FC<UrgentIssuesAlertProps> = ({ issues }) => {
         </div>
       </div>
 
-      <ScrollArea className="h-[500px] w-full rounded-b-2xl">
+      <div className="max-h-[450px] overflow-y-auto">
         <div className="flex flex-col">
           {issues.map((issue, index) => (
             <div
@@ -74,7 +73,7 @@ const UrgentIssuesAlert: React.FC<UrgentIssuesAlertProps> = ({ issues }) => {
             </div>
           ))}
         </div>
-      </ScrollArea>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## 🔗 Related Issue

Issuse: #242 

## 🆕 What’s changed?

- update model stg_fb_post to handle posted_date is null by using the crawled_date instead

## 🎯 Purpose

- for better date handling

## 📸 Screenshot at your local?

- TBC

## ⚠️ Breaking changes?

- [ ] Yes
- [ ] No
