### PR TITLE
feat: implement GitHub Action trigger functionality with admin access

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -26,6 +26,7 @@ import { BullModule } from '@nestjs/bullmq';
 import { FeedbackSimilarityModule } from './modules/feedback-similarity/feedback-similarity.module';
 import { SocialListeningModule } from './modules/social_listening/social_listening.module';
 import { SocialDataSourceModule } from './modules/social_data_source/social_data_source.module';
+import { GithubActionModule } from './modules/github-action/github-action.module';
 
 @Module({
   imports: [
@@ -59,6 +60,7 @@ import { SocialDataSourceModule } from './modules/social_data_source/social_data
     FeedbackSimilarityModule,
     SocialListeningModule,
     SocialDataSourceModule,
+    GithubActionModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/modules/github-action/dto/trigger-action.dto.ts
+++ b/backend/src/modules/github-action/dto/trigger-action.dto.ts
@@ -1,0 +1,35 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class TriggerGithubActionDto {
+  @ApiProperty({ description: 'GitHub Repository Owner', example: 'octocat' })
+  @IsString()
+  @IsNotEmpty()
+  owner: string;
+
+  @ApiProperty({
+    description: 'GitHub Repository Name',
+    example: 'hello-world',
+  })
+  @IsString()
+  @IsNotEmpty()
+  repo: string;
+
+  @ApiProperty({ description: 'Workflow file name or ID', example: 'main.yml' })
+  @IsString()
+  @IsNotEmpty()
+  workflowId: string;
+
+  @ApiProperty({ description: 'Git ref (branch or tag)', example: 'main' })
+  @IsString()
+  @IsNotEmpty()
+  ref: string;
+
+  @ApiProperty({
+    description: 'Additional inputs for the workflow',
+    required: false,
+  })
+  @IsOptional()
+  inputs?: Record<string, any>;
+}

--- a/backend/src/modules/github-action/github-action.controller.ts
+++ b/backend/src/modules/github-action/github-action.controller.ts
@@ -1,0 +1,32 @@
+import { Controller, Post, Body, UseGuards } from '@nestjs/common';
+import { GithubActionService } from './github-action.service';
+import { TriggerGithubActionDto } from './dto/trigger-action.dto';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { UserRole } from '@prisma/client';
+
+@ApiTags('Github Actions')
+@ApiBearerAuth()
+@Controller('github-action')
+@UseGuards(RolesGuard)
+export class GithubActionController {
+  constructor(private readonly githubActionService: GithubActionService) {}
+
+  @Post('trigger')
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({ summary: 'Trigger a GitHub Action workflow (Admin only)' })
+  @ApiResponse({ status: 200, description: 'Workflow triggered successfully.' })
+  @ApiResponse({
+    status: 500,
+    description: 'GitHub PAT is not configured or GitHub API failed.',
+  })
+  triggerWorkflow(@Body() dto: TriggerGithubActionDto) {
+    return this.githubActionService.triggerWorkflow(dto);
+  }
+}

--- a/backend/src/modules/github-action/github-action.module.ts
+++ b/backend/src/modules/github-action/github-action.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { GithubActionController } from './github-action.controller';
+import { GithubActionService } from './github-action.service';
+
+@Module({
+  controllers: [GithubActionController],
+  providers: [GithubActionService],
+})
+export class GithubActionModule {}

--- a/backend/src/modules/github-action/github-action.service.ts
+++ b/backend/src/modules/github-action/github-action.service.ts
@@ -1,0 +1,56 @@
+import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { TriggerGithubActionDto } from './dto/trigger-action.dto';
+
+@Injectable()
+export class GithubActionService {
+  constructor(private configService: ConfigService) {}
+
+  async triggerWorkflow(dto: TriggerGithubActionDto) {
+    const token = this.configService.get<string>('GITHUB_PAT');
+
+    if (!token) {
+      throw new HttpException(
+        'GITHUB_PAT is not configured in the environment variables.',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+
+    const { owner, repo, workflowId, ref, inputs } = dto;
+    const url = `https://api.github.com/repos/${owner}/${repo}/actions/workflows/${workflowId}/dispatches`;
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/vnd.github.v3+json',
+          Authorization: `token ${token}`,
+          'Content-Type': 'application/json',
+          'User-Agent': 'uni-feedback-portal',
+        },
+        body: JSON.stringify({
+          ref: ref,
+          inputs: inputs || {},
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.text();
+        throw new HttpException(
+          `GitHub API error: ${errorData}`,
+          response.status,
+        );
+      }
+
+      return { message: 'GitHub Action triggered successfully!' };
+    } catch (error) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      throw new HttpException(
+        'Failed to trigger GitHub Action',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+}

--- a/frontend/src/app/(layout)/admin/social-listening/page.tsx
+++ b/frontend/src/app/(layout)/admin/social-listening/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { DataSourceCardGrid } from "@/components/dashboard/social-listening/data-source-card-grid";
 import { AddDataSourceDialog } from "@/components/dashboard/social-listening/add-data-source-dialog";
+import { TriggerPipelineButton } from "@/components/dashboard/social-listening/trigger-pipeline-button";
 import Wrapper from "@/components/shared/Wrapper";
 import { Input } from "@/components/ui/input";
 import { useGetSocialDataSources } from "@/hooks/queries/useSocialDataSourceQueries";
@@ -35,18 +36,21 @@ const AdminSocialListeningPage = () => {
             Quản lý các nguồn dữ liệu mạng xã hội (Facebook Groups). Thêm mới,
             chỉnh sửa thông tin hoặc cấu hình để hệ thống tự động cào dữ liệu.
           </p>
-          <div className="mt-6 flex items-center justify-center gap-4">
-            <div className="relative w-full max-w-md">
+          <div className="mt-6 flex w-full flex-col items-center justify-center gap-4 sm:flex-row">
+            <div className="relative w-full sm:max-w-md">
               <Search className="absolute top-1/2 left-4 h-5 w-5 -translate-y-1/2 text-slate-400" />
               <Input
                 type="text"
                 placeholder="Tìm kiếm tên hoặc url..."
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                className="h-12 w-full rounded-full border-slate-200 bg-white pl-12 text-base shadow-sm transition-all focus-visible:ring-indigo-500"
+                className="h-10 w-full rounded-md border-slate-200 bg-white pl-11 text-base shadow-sm transition-all focus-visible:ring-indigo-500"
               />
             </div>
-            <AddDataSourceDialog />
+            <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row">
+              <AddDataSourceDialog />
+              <TriggerPipelineButton />
+            </div>
           </div>
         </div>
 

--- a/frontend/src/components/dashboard/social-listening/add-data-source-dialog.tsx
+++ b/frontend/src/components/dashboard/social-listening/add-data-source-dialog.tsx
@@ -66,7 +66,7 @@ export function AddDataSourceDialog() {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button className="bg-indigo-600 text-white hover:bg-indigo-700">
+        <Button className="w-full bg-indigo-600 text-white hover:bg-indigo-700 sm:w-auto">
           <Plus className="mr-2 h-4 w-4" />
           Thêm Mới
         </Button>

--- a/frontend/src/components/dashboard/social-listening/trigger-pipeline-button.tsx
+++ b/frontend/src/components/dashboard/social-listening/trigger-pipeline-button.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useState } from "react";
+import { Play, CheckCircle2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { useTriggerGithubAction } from "@/hooks/queries/useGithubActionQueries";
+
+export function TriggerPipelineButton() {
+  const [open, setOpen] = useState(false);
+  const [showSuccess, setShowSuccess] = useState(false);
+  const { mutateAsync: triggerPipeline, isPending } = useTriggerGithubAction();
+
+  const handleTrigger = async () => {
+    try {
+      await triggerPipeline({
+        owner: "zzVu77",
+        repo: "uni-feedback-portal",
+        workflowId: "daily-pipeline.yml",
+        ref: "main",
+        inputs: {},
+      });
+      setOpen(false);
+      setShowSuccess(true);
+    } catch (error) {
+      console.error("Error triggering pipeline:", error);
+    }
+  };
+
+  return (
+    <>
+      <AlertDialog open={open} onOpenChange={setOpen}>
+        <AlertDialogTrigger asChild>
+          <Button className="w-full bg-emerald-600 text-white hover:bg-emerald-700 sm:w-auto">
+            <Play className="mr-2 h-4 w-4" />
+            Phân tích dữ liệu ngay
+          </Button>
+        </AlertDialogTrigger>
+        <AlertDialogContent className="rounded-[24px] p-6 sm:p-8">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="text-xl font-bold">
+              Xác nhận kích hoạt Pipeline
+            </AlertDialogTitle>
+            <AlertDialogDescription className="text-base text-slate-600">
+              Hành động này sẽ gọi Github Action để tiến hành cào dữ liệu mới
+              nhất từ các nguồn mạng xã hội (Facebook Groups) hiện tại và phân
+              tích bằng AI. Quá trình có thể mất vài phút. Bạn có chắc chắn muốn
+              chạy ngay bây giờ?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="mt-6 gap-3">
+            <AlertDialogCancel className="h-11 rounded-full px-6 font-semibold">
+              Hủy
+            </AlertDialogCancel>
+            <Button
+              className="h-11 rounded-full bg-emerald-600 px-6 font-semibold text-white shadow-md hover:bg-emerald-700"
+              onClick={handleTrigger}
+              disabled={isPending}
+            >
+              {isPending ? "Đang kích hoạt..." : "Xác nhận chạy"}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={showSuccess} onOpenChange={setShowSuccess}>
+        <AlertDialogContent className="max-w-md rounded-[24px] p-8 text-center">
+          <div className="flex flex-col items-center gap-4">
+            <div className="rounded-full bg-emerald-100 p-4">
+              <CheckCircle2 className="h-12 w-12 text-emerald-600" />
+            </div>
+            <AlertDialogHeader>
+              <AlertDialogTitle className="text-center text-2xl font-bold text-slate-800">
+                Kích hoạt thành công!
+              </AlertDialogTitle>
+              <AlertDialogDescription className="mt-2 text-center text-base text-slate-600">
+                Data Pipeline đã được bắt đầu trên GitHub Actions. Quá trình thu
+                thập và phân tích dữ liệu AI sẽ diễn ra ngầm. Vui lòng quay lại
+                kiểm tra biểu đồ và danh sách sự cố sau khoảng{" "}
+                <b className="text-emerald-700">5-7 phút</b> nữa.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter className="mt-6 w-full">
+              <AlertDialogAction className="h-12 w-full rounded-full bg-indigo-600 text-base font-semibold text-white hover:bg-indigo-700">
+                Đã hiểu
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </div>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/frontend/src/components/dashboard/social-listening/trigger-pipeline-button.tsx
+++ b/frontend/src/components/dashboard/social-listening/trigger-pipeline-button.tsx
@@ -86,7 +86,7 @@ export function TriggerPipelineButton() {
               <AlertDialogDescription className="mt-2 text-center text-base text-slate-600">
                 Data Pipeline đã được bắt đầu trên GitHub Actions. Quá trình thu
                 thập và phân tích dữ liệu AI sẽ diễn ra ngầm. Vui lòng quay lại
-                kiểm tra biểu đồ và danh sách sự cố sau khoảng{" "}
+                kiểm tra biểu đồ và dữ liệu sau khoảng{" "}
                 <b className="text-emerald-700">5-7 phút</b> nữa.
               </AlertDialogDescription>
             </AlertDialogHeader>

--- a/frontend/src/hooks/queries/useGithubActionQueries.ts
+++ b/frontend/src/hooks/queries/useGithubActionQueries.ts
@@ -1,0 +1,22 @@
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { useMutation } from "@tanstack/react-query";
+import {
+  triggerGithubAction,
+  TriggerGithubActionPayload,
+} from "@/services/github-action-service";
+import { toast } from "sonner";
+
+export const useTriggerGithubAction = () => {
+  return useMutation({
+    mutationFn: (payload: TriggerGithubActionPayload) =>
+      triggerGithubAction(payload),
+    onError: (error: any) => {
+      toast.error(
+        error?.response?.data?.message ||
+          "Có lỗi xảy ra khi kích hoạt Pipeline!",
+      );
+    },
+  });
+};

--- a/frontend/src/services/github-action-service.ts
+++ b/frontend/src/services/github-action-service.ts
@@ -1,0 +1,18 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import axiosInstance from "@/config/axiosConfig";
+
+export interface TriggerGithubActionPayload {
+  owner: string;
+  repo: string;
+  workflowId: string;
+  ref: string;
+  inputs?: Record<string, any>;
+}
+
+export const triggerGithubAction = async (
+  payload: TriggerGithubActionPayload,
+) => {
+  const response = await axiosInstance.post("/github-action/trigger", payload);
+  return response;
+};


### PR DESCRIPTION
## 🔗 Related Issue

Issuse: #256 

## 🆕 What’s changed?

- add new endpoint to allow admin trigger pipeline manually
- update ui of  admin social listening

## 🎯 Purpose

- allow admin proactively trigger the pipeline

## 📸 Screenshot at your local?

- 
<img width="1919" height="1024" alt="image" src="https://github.com/user-attachments/assets/60970424-b985-4daa-b320-4be59b3b9801" />

- 
<img width="1919" height="1031" alt="image" src="https://github.com/user-attachments/assets/4c857230-d509-4013-bfda-cc02d5a98dc2" />

- 
<img width="1919" height="1027" alt="image" src="https://github.com/user-attachments/assets/01936ad8-ebe1-4e01-8f29-02497fa2f0a1" />


## ⚠️ Breaking changes?

- [ ] Yes
- [ ] No
